### PR TITLE
`styles` should not be any type when non-existent file/value is imported

### DIFF
--- a/packages/codegen/e2e/index.test.ts
+++ b/packages/codegen/e2e/index.test.ts
@@ -35,23 +35,29 @@ test('generates .d.ts', async () => {
   expect(hcm.stderr.toString()).toBe('');
   expect(hcm.status).toBe(0);
   expect(await readFile(iff.join('dist/src/a.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
-    "declare const styles = {
+    "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+    function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+    declare const styles = {
       a1: '' as readonly string,
-      ...(await import('./b.module.css')).default,
-      ...(await import('@/c.module.css')).default,
+      ...anyToEmptyObject((await import('./b.module.css')).default),
+      ...anyToEmptyObject((await import('@/c.module.css')).default),
     };
     export default styles;
     "
   `);
   expect(await readFile(iff.join('dist/src/b.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
-    "declare const styles = {
+    "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+    function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+    declare const styles = {
       b1: '' as readonly string,
     };
     export default styles;
     "
   `);
   expect(await readFile(iff.join('dist/src/c.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
-    "declare const styles = {
+    "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+    function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+    declare const styles = {
       c1: '' as readonly string,
     };
     export default styles;
@@ -102,25 +108,31 @@ test('generates .d.ts with circular import', async () => {
   expect(hcm.stderr.toString()).toBe('');
   expect(hcm.status).toBe(0);
   expect(await readFile(iff.join('dist/src/a.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
-    "declare const styles = {
+    "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+    function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+    declare const styles = {
       a1: '' as readonly string,
-      ...(await import('./b.module.css')).default,
+      ...anyToEmptyObject((await import('./b.module.css')).default),
     };
     export default styles;
     "
   `);
   expect(await readFile(iff.join('dist/src/b.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
-    "declare const styles = {
+    "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+    function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+    declare const styles = {
       b1: '' as readonly string,
-      ...(await import('./a.module.css')).default,
+      ...anyToEmptyObject((await import('./a.module.css')).default),
     };
     export default styles;
     "
   `);
   expect(await readFile(iff.join('dist/src/c.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
-    "declare const styles = {
+    "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+    function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+    declare const styles = {
       c1: '' as readonly string,
-      ...(await import('./c.module.css')).default,
+      ...anyToEmptyObject((await import('./c.module.css')).default),
     };
     export default styles;
     "

--- a/packages/codegen/src/runner.test.ts
+++ b/packages/codegen/src/runner.test.ts
@@ -51,14 +51,18 @@ describe('runHCM', () => {
       createLoggerSpy(),
     );
     expect(await readFile(iff.join('generated/src/a.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
-      "declare const styles = {
+      "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+      function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+      declare const styles = {
         a1: '' as readonly string,
       };
       export default styles;
       "
     `);
     expect(await readFile(iff.join('generated/src/b.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
-      "declare const styles = {
+      "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+      function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+      declare const styles = {
         b1: '' as readonly string,
       };
       export default styles;
@@ -88,8 +92,10 @@ describe('runHCM', () => {
       createLoggerSpy(),
     );
     expect(await readFile(iff.join('generated/src/a.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
-      "declare const styles = {
-        ...(await import('./b.module.css')).default,
+      "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+      function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+      declare const styles = {
+        ...anyToEmptyObject((await import('./b.module.css')).default),
       };
       export default styles;
       "
@@ -138,7 +144,9 @@ describe('runHCM', () => {
       createLoggerSpy(),
     );
     expect(await readFile(iff.join('generated/src/a.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
-      "declare const styles = {
+      "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+      function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+      declare const styles = {
         a1: '' as readonly string,
       };
       export default styles;

--- a/packages/core/src/dts-creator.test.ts
+++ b/packages/core/src/dts-creator.test.ts
@@ -35,7 +35,9 @@ describe('createDts', () => {
           "lengths": [],
           "sourceOffsets": [],
         },
-        "text": "declare const styles = {};
+        "text": "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+      function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+      declare const styles = {};
       export default styles;
       ",
       }
@@ -67,8 +69,8 @@ describe('createDts', () => {
         },
         "mapping": {
           "generatedOffsets": [
-            27,
-            60,
+            156,
+            189,
           ],
           "lengths": [
             6,
@@ -79,7 +81,9 @@ describe('createDts', () => {
             1,
           ],
         },
-        "text": "declare const styles = {
+        "text": "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+      function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+      declare const styles = {
         local1: '' as readonly string,
         local2: '' as readonly string,
       };
@@ -127,27 +131,27 @@ describe('createDts', () => {
             9,
           ],
           "generatedOffsets": [
-            126,
-            198,
+            286,
+            372,
           ],
           "lengths": [
             9,
             16,
           ],
           "sourceOffsets": [
-            74,
-            139,
+            221,
+            300,
           ],
         },
         "mapping": {
           "generatedOffsets": [
-            44,
-            74,
-            99,
-            126,
-            139,
-            171,
-            198,
+            190,
+            221,
+            259,
+            286,
+            300,
+            345,
+            372,
           ],
           "lengths": [
             16,
@@ -168,10 +172,12 @@ describe('createDts', () => {
             4,
           ],
         },
-        "text": "declare const styles = {
-        ...(await import('./a.module.css')).default,
-        imported1: (await import('./b.module.css')).default.imported1,
-        aliasedImported2: (await import('./c.module.css')).default.imported2,
+        "text": "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+      function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+      declare const styles = {
+        ...anyToEmptyObject((await import('./a.module.css')).default),
+        imported1: anyToUnknown((await import('./b.module.css')).default.imported1),
+        aliasedImported2: anyToUnknown((await import('./c.module.css')).default.imported2),
       };
       export default styles;
       ",
@@ -198,8 +204,8 @@ describe('createDts', () => {
         },
         "mapping": {
           "generatedOffsets": [
-            27,
-            77,
+            156,
+            223,
           ],
           "lengths": [
             6,
@@ -210,9 +216,11 @@ describe('createDts', () => {
             0,
           ],
         },
-        "text": "declare const styles = {
+        "text": "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+      function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+      declare const styles = {
         local1: '' as readonly string,
-        ...(await import('./a.module.css')).default,
+        ...anyToEmptyObject((await import('./a.module.css')).default),
       };
       export default styles;
       ",
@@ -259,27 +267,27 @@ describe('createDts', () => {
             9,
           ],
           "generatedOffsets": [
-            126,
-            198,
+            286,
+            372,
           ],
           "lengths": [
             9,
             16,
           ],
           "sourceOffsets": [
-            74,
-            139,
+            221,
+            300,
           ],
         },
         "mapping": {
           "generatedOffsets": [
-            44,
-            74,
-            99,
-            126,
-            139,
-            171,
-            198,
+            190,
+            221,
+            259,
+            286,
+            300,
+            345,
+            372,
           ],
           "lengths": [
             16,
@@ -300,10 +308,12 @@ describe('createDts', () => {
             4,
           ],
         },
-        "text": "declare const styles = {
-        ...(await import('@/a.module.css')).default,
-        imported1: (await import('@/b.module.css')).default.imported1,
-        aliasedImported2: (await import('@/c.module.css')).default.imported2,
+        "text": "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+      function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+      declare const styles = {
+        ...anyToEmptyObject((await import('@/a.module.css')).default),
+        imported1: anyToUnknown((await import('@/b.module.css')).default.imported1),
+        aliasedImported2: anyToUnknown((await import('@/c.module.css')).default.imported2),
       };
       export default styles;
       ",
@@ -348,7 +358,9 @@ describe('createDts', () => {
           "lengths": [],
           "sourceOffsets": [],
         },
-        "text": "declare const styles = {};
+        "text": "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+      function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+      declare const styles = {};
       export default styles;
       ",
       }
@@ -378,7 +390,9 @@ describe('createDts', () => {
           "lengths": [],
           "sourceOffsets": [],
         },
-        "text": "declare const styles = {};
+        "text": "function anyToEmptyObject<T>(val: T): 0 extends 1 & T ? {} : T;
+      function anyToUnknown<T>(val: T): 0 extends 1 & T ? unknown : T;
+      declare const styles = {};
       export default styles;
       ",
       }

--- a/packages/ts-plugin/e2e/semantic-diagnostics.test.ts
+++ b/packages/ts-plugin/e2e/semantic-diagnostics.test.ts
@@ -8,7 +8,7 @@ test('Semantic Diagnostics', async () => {
   const iff = await createIFF({
     'index.ts': dedent`
       import styles from './a.module.css';
-      type Expected = { a_1: string, a_2: string, b_1: string, c_1: string, c_alias: string };
+      type Expected = { a_1: string, a_2: string, b_1: string, c_1: string, c_alias: string, c_3: unknown };
       const t1: Expected = styles;
       const t2: typeof styles = 0 as any as Expected;
       styles.unknown;
@@ -45,8 +45,23 @@ test('Semantic Diagnostics', async () => {
   const res1 = await tsserver.sendSemanticDiagnosticsSync({
     file: iff.paths['index.ts'],
   });
-  // TODO: Report type errors
-  expect(res1.body).toMatchInlineSnapshot(`[]`);
+  expect(res1.body).toMatchInlineSnapshot(`
+    [
+      {
+        "category": "error",
+        "code": 2339,
+        "end": {
+          "line": 5,
+          "offset": 15,
+        },
+        "start": {
+          "line": 5,
+          "offset": 8,
+        },
+        "text": "Property 'unknown' does not exist on type '{ c_1: string; c_alias: string; c_3: any; b_1: string; a_1: string; a_2: string; }'.",
+      },
+    ]
+  `);
 
   const res2 = await tsserver.sendSemanticDiagnosticsSync({
     file: iff.paths['a.module.css'],


### PR DESCRIPTION
When writing code by trial and error in the editor, it's not uncommon to import non-existent files or values. In such cases, the `styles` exported from `*.module.css` ends up with the `any` type.

```css
// a.module.css
.a_1 { color: red; }
@import './b.module.css';
/*       ^^^^^^^^^^^^^^ non-existent file */
@value c_1, c_2 from './c.module.css';
/*          ^^^ non-existent value */
```

```css
// c.module.css
@value c_1: red;
```

```ts
// a.ts
import styles from './a.module.css';
console.log(styles.a_1);
//          ^? any
```

As a result, [no-unsafe-member-access](https://typescript-eslint.io/rules/no-unsafe-member-access/) rule warns the code like `styles.foo`. It can be bothersome for users.

Therefore, we want to ensure that `styles` does not become `any` type even if a non-existent file or value is imported.

```ts
// a.ts
import styles from './a.module.css';
console.log(styles.a_1);
//          ^? { a_1: string, c_1: string }
```
