### PR TITLE
Remove unused codes

### DIFF
--- a/.changeset/soft-jokes-sparkle.md
+++ b/.changeset/soft-jokes-sparkle.md
@@ -1,0 +1,7 @@
+---
+'@css-modules-kit/core': patch
+'@css-modules-kit/codegen': patch
+'@css-modules-kit/ts-plugin': patch
+---
+
+refactor: remove unused codes

--- a/packages/codegen/e2e/index.test.ts
+++ b/packages/codegen/e2e/index.test.ts
@@ -29,9 +29,6 @@ test('generates .d.ts', async () => {
   });
   const cmk = spawnSync('node', [binPath], {
     cwd: iff.rootDir,
-    // MEMO: Suppress ExperimentalWarning output from `fs.promises.glob` and `path.matchesGlob`
-    // TODO: Remove `--no-warnings=ExperimentalWarning`
-    env: { ...process.env, NODE_OPTIONS: '--no-warnings=ExperimentalWarning' },
   });
   expect(cmk.error).toBeUndefined();
   expect(cmk.stderr.toString()).toBe('');
@@ -97,9 +94,6 @@ test('generates .d.ts with circular import', async () => {
   });
   const cmk = spawnSync('node', [binPath], {
     cwd: iff.rootDir,
-    // MEMO: Suppress ExperimentalWarning output from `fs.promises.glob` and `path.matchesGlob`
-    // TODO: Remove `--no-warnings=ExperimentalWarning`
-    env: { ...process.env, NODE_OPTIONS: '--no-warnings=ExperimentalWarning' },
   });
   expect(cmk.error).toBeUndefined();
   expect(cmk.stderr.toString()).toBe('');

--- a/packages/codegen/src/runner.ts
+++ b/packages/codegen/src/runner.ts
@@ -25,14 +25,14 @@ import type { Logger } from './logger/logger.js';
 /**
  * @throws {ReadCSSModuleFileError} When failed to read CSS Module file.
  */
-async function parseCSSModuleByFileName(fileName: string, { dashedIdents }: CMKConfig): Promise<ParseCSSModuleResult> {
+async function parseCSSModuleByFileName(fileName: string): Promise<ParseCSSModuleResult> {
   let text: string;
   try {
     text = await readFile(fileName, 'utf-8');
   } catch (error) {
     throw new ReadCSSModuleFileError(fileName, error);
   }
-  return parseCSSModule(text, { fileName, dashedIdents, safe: false });
+  return parseCSSModule(text, { fileName, safe: false });
 }
 
 /**
@@ -84,7 +84,7 @@ export async function runCMK(project: string, logger: Logger): Promise<void> {
     ]);
     return;
   }
-  const parseResults = await Promise.all(fileNames.map(async (fileName) => parseCSSModuleByFileName(fileName, config)));
+  const parseResults = await Promise.all(fileNames.map(async (fileName) => parseCSSModuleByFileName(fileName)));
   for (const parseResult of parseResults) {
     cssModuleMap.set(parseResult.cssModule.fileName, parseResult.cssModule);
     syntacticDiagnostics.push(...parseResult.diagnostics);

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -291,7 +291,6 @@ describe('normalizeConfig', () => {
     ).toMatchInlineSnapshot(`
       {
         "arbitraryExtensions": false,
-        "dashedIdents": false,
         "dtsOutDir": "/app/generated",
         "excludes": [
           "/app/src/test",
@@ -316,7 +315,6 @@ describe('normalizeConfig', () => {
     ).toMatchInlineSnapshot(`
       {
         "arbitraryExtensions": false,
-        "dashedIdents": false,
         "dtsOutDir": "/app/generated",
         "excludes": [],
         "includes": [

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -202,7 +202,6 @@ function mergeParsedRawData(base: ParsedRawData, overrides: ParsedRawData): Pars
 /**
  * @throws {TsConfigFileNotFoundError}
  */
-// TODO: Allow `extends` options to inherit `cmkOptions`
 export function readTsConfigFile(project: string): {
   configFileName: string;
 } & ParsedRawData {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -20,7 +20,6 @@ export interface CMKConfig {
   paths: Record<string, string[]>;
   dtsOutDir: string;
   arbitraryExtensions: boolean;
-  dashedIdents: boolean;
   /**
    * A root directory to resolve relative path entries in the config file to.
    * This is an absolute path.
@@ -271,7 +270,7 @@ function resolvePaths(paths: Record<string, string[]> | undefined, cwd: string):
 export function normalizeConfig(
   config: UnnormalizedCMKConfig,
   basePath: string,
-): RemoveUndefined<UnnormalizedCMKConfig> & { dashedIdents: boolean } {
+): RemoveUndefined<UnnormalizedCMKConfig> {
   return {
     // If `include` is not specified, fallback to the default include spec.
     // ref: https://github.com/microsoft/TypeScript/blob/caf1aee269d1660b4d2a8b555c2d602c97cb28d7/src/compiler/commandLineParser.ts#L3102
@@ -280,6 +279,5 @@ export function normalizeConfig(
     paths: resolvePaths(config.paths, basePath),
     dtsOutDir: join(basePath, config.dtsOutDir ?? 'generated'),
     arbitraryExtensions: config.arbitraryExtensions ?? false,
-    dashedIdents: false, // TODO: Support dashedIdents
   };
 }

--- a/packages/core/src/parser/css-module-parser.test.ts
+++ b/packages/core/src/parser/css-module-parser.test.ts
@@ -2,7 +2,7 @@ import dedent from 'dedent';
 import { describe, expect, test } from 'vitest';
 import { parseCSSModule, type ParseCSSModuleOptions } from './css-module-parser.js';
 
-const options: ParseCSSModuleOptions = { fileName: '/test.module.css', dashedIdents: false, safe: false };
+const options: ParseCSSModuleOptions = { fileName: '/test.module.css', safe: false };
 
 describe('parseCSSModule', () => {
   test('collects local tokens', () => {
@@ -428,22 +428,7 @@ describe('parseCSSModule', () => {
   });
   // TODO: Support local tokens by CSS variables. This is supported by lightningcss.
   // https://github.com/parcel-bundler/lightningcss/blob/a3390fd4140ca87f5035595d22bc9357cf72177e/src/css_modules.rs#L34
-  test.fails('collects local tokens as CSS variables if dashedIdents is true', () => {
-    const text1 = ':root { --a: red; }';
-    const parsed1 = parseCSSModule(text1, { ...options, dashedIdents: false });
-    expect(parsed1.cssModule?.localTokens).toEqual([]);
 
-    const text2 = dedent`
-        :root { --a: red; }
-        .a {
-          color: var(--b);
-          background-color: var(--c from './a.module.css');
-          background-color: var(--d from global);
-        }
-      `;
-    const parsed2 = parseCSSModule(text2, { ...options, dashedIdents: true });
-    expect(parsed2.cssModule?.localTokens).toEqual(['--a', 'a', '--b']);
-  });
   // TODO: Support local tokens by animation names. This is supported by postcss-modules-local-by-default and lightningcss.
   // https://github.com/css-modules/postcss-modules-local-by-default/blob/39a2f78d9f39f5c0e30dd9b2a25f4a145431cb20/test/index.test.js#L162-L399
   // https://github.com/parcel-bundler/lightningcss/blob/a3390fd4140ca87f5035595d22bc9357cf72177e/src/css_modules.rs#L37

--- a/packages/core/src/parser/css-module-parser.ts
+++ b/packages/core/src/parser/css-module-parser.ts
@@ -147,7 +147,6 @@ export interface CSSModule {
 
 export interface ParseCSSModuleOptions {
   fileName: string;
-  dashedIdents: boolean;
   safe: boolean;
 }
 

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -37,7 +37,7 @@ const plugin = createLanguageServicePlugin((ts, info) => {
   const matchesPattern = createMatchesPattern(config);
 
   return {
-    languagePlugins: [createCSSModuleLanguagePlugin(config, resolver, matchesPattern)],
+    languagePlugins: [createCSSModuleLanguagePlugin(resolver, matchesPattern)],
     setup: (language) => {
       info.languageService = proxyLanguageService(
         language,

--- a/packages/ts-plugin/src/language-plugin.ts
+++ b/packages/ts-plugin/src/language-plugin.ts
@@ -1,4 +1,4 @@
-import type { CMKConfig, CSSModule, MatchesPattern, Resolver, SyntacticDiagnostic } from '@css-modules-kit/core';
+import type { CSSModule, MatchesPattern, Resolver, SyntacticDiagnostic } from '@css-modules-kit/core';
 import { createDts, parseCSSModule } from '@css-modules-kit/core';
 import type { LanguagePlugin, SourceScript, VirtualCode } from '@volar/language-core';
 import type {} from '@volar/typescript';
@@ -22,7 +22,6 @@ export interface CSSModuleScript extends SourceScript<string> {
 }
 
 export function createCSSModuleLanguagePlugin(
-  config: CMKConfig,
   resolver: Resolver,
   matchesPattern: MatchesPattern,
 ): LanguagePlugin<string, VirtualCode> {
@@ -38,7 +37,6 @@ export function createCSSModuleLanguagePlugin(
       const cssModuleCode = snapshot.getText(0, length);
       const { cssModule, diagnostics } = parseCSSModule(cssModuleCode, {
         fileName: scriptId,
-        dashedIdents: config.dashedIdents,
         // The CSS in the process of being written in an editor often contains invalid syntax.
         // So, ts-plugin uses a fault-tolerant Parser to parse CSS.
         safe: true,


### PR DESCRIPTION
- The code for the `dashedIdents` option is written but incomplete. Therefore, remove it.
- Remove any other unnecessary codes.