### PR TITLE
Handle CLI argument parsing errors

### DIFF
--- a/.changeset/poor-towns-matter.md
+++ b/.changeset/poor-towns-matter.md
@@ -1,0 +1,5 @@
+---
+'@css-modules-kit/codegen': patch
+---
+
+fix: handle CLI argument parsing errors

--- a/packages/codegen/bin/cmk.mjs
+++ b/packages/codegen/bin/cmk.mjs
@@ -5,19 +5,20 @@ import { SystemError } from '@css-modules-kit/core';
 import { createLogger, parseCLIArgs, printHelpText, printVersion, runCMK, shouldBePretty } from '../dist/index.js';
 
 const cwd = process.cwd();
-const args = parseCLIArgs(process.argv.slice(2), cwd);
-
-if (args.help) {
-  printHelpText();
-  process.exit(0);
-} else if (args.version) {
-  printVersion();
-  process.exit(0);
-}
-
-const logger = createLogger(cwd, shouldBePretty(args.pretty));
+let logger = createLogger(cwd, shouldBePretty(undefined));
 
 try {
+  const args = parseCLIArgs(process.argv.slice(2), cwd);
+  logger = createLogger(cwd, shouldBePretty(args.pretty));
+
+  if (args.help) {
+    printHelpText();
+    process.exit(0);
+  } else if (args.version) {
+    printVersion();
+    process.exit(0);
+  }
+
   await runCMK(args.project, logger);
 } catch (e) {
   if (e instanceof SystemError) {

--- a/packages/codegen/src/cli.test.ts
+++ b/packages/codegen/src/cli.test.ts
@@ -1,6 +1,7 @@
 import { resolve } from '@css-modules-kit/core';
 import { describe, expect, it } from 'vitest';
 import { parseCLIArgs } from './cli.js';
+import { ParseCLIArgsError } from './error.js';
 
 const cwd = '/app';
 
@@ -35,5 +36,7 @@ describe('parseCLIArgs', () => {
     expect(parseCLIArgs(['--pretty'], cwd).pretty).toBe(true);
     expect(parseCLIArgs(['--no-pretty'], cwd).pretty).toBe(false);
   });
-  // TODO: Add tests for invalid options
+  it('should throw ParseCLIArgsError for invalid options', () => {
+    expect(() => parseCLIArgs(['--invalid-option'], cwd)).toThrow(ParseCLIArgsError);
+  });
 });

--- a/packages/codegen/src/cli.ts
+++ b/packages/codegen/src/cli.ts
@@ -31,7 +31,6 @@ export interface ParsedArgs {
 
 /**
  * Parse command-line arguments.
- * If `--help` or `--version` is passed, print the corresponding information and exit the process.
  */
 export function parseCLIArgs(args: string[], cwd: string): ParsedArgs {
   const { values } = parseArgs({

--- a/packages/codegen/src/cli.ts
+++ b/packages/codegen/src/cli.ts
@@ -1,6 +1,7 @@
 import { parseArgs } from 'node:util';
 import { resolve } from '@css-modules-kit/core';
 import packageJson from '../package.json';
+import { ParseCLIArgsError } from './error.js';
 
 const helpText = `
 Usage: cmk [options]
@@ -31,22 +32,27 @@ export interface ParsedArgs {
 
 /**
  * Parse command-line arguments.
+ * @throws {ParseCLIArgsError} If failed to parse CLI arguments.
  */
 export function parseCLIArgs(args: string[], cwd: string): ParsedArgs {
-  const { values } = parseArgs({
-    args,
-    options: {
-      help: { type: 'boolean', short: 'h', default: false },
-      version: { type: 'boolean', short: 'v', default: false },
-      project: { type: 'string', short: 'p', default: '.' },
-      pretty: { type: 'boolean' },
-    },
-    allowNegative: true,
-  });
-  return {
-    help: values.help,
-    version: values.version,
-    project: resolve(cwd, values.project),
-    pretty: values.pretty,
-  };
+  try {
+    const { values } = parseArgs({
+      args,
+      options: {
+        help: { type: 'boolean', short: 'h', default: false },
+        version: { type: 'boolean', short: 'v', default: false },
+        project: { type: 'string', short: 'p', default: '.' },
+        pretty: { type: 'boolean' },
+      },
+      allowNegative: true,
+    });
+    return {
+      help: values.help,
+      version: values.version,
+      project: resolve(cwd, values.project),
+      pretty: values.pretty,
+    };
+  } catch (cause) {
+    throw new ParseCLIArgsError(cause);
+  }
 }

--- a/packages/codegen/src/error.ts
+++ b/packages/codegen/src/error.ts
@@ -1,5 +1,11 @@
 import { SystemError } from '@css-modules-kit/core';
 
+export class ParseCLIArgsError extends SystemError {
+  constructor(cause: unknown) {
+    super('PARSE_CLI_ARGS_ERROR', `Failed to parse CLI arguments.`, cause);
+  }
+}
+
 export class WriteDtsFileError extends SystemError {
   constructor(fileName: string, cause: unknown) {
     super('WRITE_DTS_FILE_ERROR', `Failed to write .d.ts file ${fileName}.`, cause);


### PR DESCRIPTION
```console
$ node ../packages/codegen/bin/cmk.mjs -a                    
error PARSE_CLI_ARGS_ERROR: Failed to parse CLI arguments.
  [cause]: TypeError [ERR_PARSE_ARGS_UNKNOWN_OPTION]: Unknown option '-a'
      at checkOptionUsage (node:internal/util/parse_args/parse_args:107:13)
      at node:internal/util/parse_args/parse_args:381:9
      at Array.forEach (<anonymous>)
      at parseArgs (node:internal/util/parse_args/parse_args:378:3)
      at parseCLIArgs (/Users/mizdra/src/github.com/mizdra/honey-css-modules/packages/codegen/dist/cli.js:36:54)
      at file:///Users/mizdra/src/github.com/mizdra/honey-css-modules/packages/codegen/bin/cmk.mjs:11:16
      at ModuleJob.run (node:internal/modules/esm/module_job:272:25)
      at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:580:26)
      at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:98:5) {
    code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION'
  }
```