### PR TITLE
Use windows-2025 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [22]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2025]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [22]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2025]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
windows-2025 seems to be faster than windows-latest.

### windows-latest

https://github.com/mizdra/css-modules-kit/actions/runs/14420260041/attempts/2

<img width="643" alt="image" src="https://github.com/user-attachments/assets/58bb76e4-8ea4-42d4-b9ca-4eb110eef6a7" />


### windows-2025

https://github.com/mizdra/css-modules-kit/actions/runs/14420266309

<img width="716" alt="image" src="https://github.com/user-attachments/assets/c3a85965-d321-4d97-b2a4-6ce9018999eb" />

