### PR TITLE
Avoid LSP request conflicts with Request Forwarding

### DIFF
--- a/.changeset/thick-pens-rule.md
+++ b/.changeset/thick-pens-rule.md
@@ -1,0 +1,5 @@
+---
+'css-modules-kit-vscode': patch
+---
+
+fix: avoid LSP request conflicts with Request Forwarding

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,6 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode",
         "--profile-temp",
-        "--disable-extension=vscode.css-language-features",
         "--skip-welcome",
         "--folder-uri=${workspaceFolder}/example",
         "${workspaceFolder}/example/src/index.tsx"

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -68,33 +68,39 @@ export async function activate(context: vscode.ExtensionContext) {
       },
     });
     context.subscriptions.push(
-      vscode.languages.registerRenameProvider(['css'], {
-        provideRenameEdits(document, position, newName, _token) {
-          // NOTE: Executing `executeDocumentRenameProvider` on a virtual text document causes a runtime error. This is probably a bug in vscode.
-          return vscode.commands.executeCommand<vscode.WorkspaceEdit>(
-            'vscode.executeDocumentRenameProvider',
-            vscode.Uri.parse(`${ORIGINAL_SCHEME}://${document.fileName}.ts`),
-            position,
-            newName,
-          );
+      vscode.languages.registerRenameProvider(
+        { language: 'css' },
+        {
+          provideRenameEdits(document, position, newName, _token) {
+            // NOTE: Executing `executeDocumentRenameProvider` on a virtual text document causes a runtime error. This is probably a bug in vscode.
+            return vscode.commands.executeCommand<vscode.WorkspaceEdit>(
+              'vscode.executeDocumentRenameProvider',
+              vscode.Uri.parse(`${ORIGINAL_SCHEME}://${document.fileName}.ts`),
+              position,
+              newName,
+            );
+          },
+          prepareRename(document, position, _token) {
+            return vscode.commands.executeCommand<RangeOrRangeWithPlaceholder>(
+              'vscode.prepareRename',
+              vscode.Uri.parse(`${ORIGINAL_SCHEME}://${document.fileName}.ts`),
+              position,
+            );
+          },
         },
-        prepareRename(document, position, _token) {
-          return vscode.commands.executeCommand<RangeOrRangeWithPlaceholder>(
-            'vscode.prepareRename',
-            vscode.Uri.parse(`${ORIGINAL_SCHEME}://${document.fileName}.ts`),
-            position,
-          );
+      ),
+      vscode.languages.registerDocumentLinkProvider(
+        { language: 'css' },
+        {
+          async provideDocumentLinks(document, _token) {
+            // NOTE: Executing `executeDocumentLinkProvider` on a virtual text document, an empty array is always returned. This is probably a bug in vscode.
+            return vscode.commands.executeCommand<vscode.Location[]>(
+              'vscode.executeLinkProvider',
+              vscode.Uri.parse(`${ORIGINAL_SCHEME}://${document.fileName}.ts`),
+            );
+          },
         },
-      }),
-      vscode.languages.registerDocumentLinkProvider(['css'], {
-        async provideDocumentLinks(document, _token) {
-          // NOTE: Executing `executeDocumentLinkProvider` on a virtual text document, an empty array is always returned. This is probably a bug in vscode.
-          return vscode.commands.executeCommand<vscode.Location[]>(
-            'vscode.executeLinkProvider',
-            vscode.Uri.parse(`${ORIGINAL_SCHEME}://${document.fileName}.ts`),
-          );
-        },
-      }),
+      ),
     );
   } else {
     // If vscode.css-language-features extension is disabled, start the customized language server for *.css, *.scss, and *.less.

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -5,7 +5,16 @@ import * as lsp from 'vscode-languageclient/node';
 
 let client: lsp.BaseLanguageClient;
 
-export async function activate(_context: vscode.ExtensionContext) {
+const ORIGINAL_SCHEME = 'css-modules-kit';
+
+type RangeOrRangeWithPlaceholder =
+  | vscode.Range
+  | {
+      range: vscode.Range;
+      placeholder: string;
+    };
+
+export async function activate(context: vscode.ExtensionContext) {
   console.log('[css-modules-kit-vscode] Activated');
 
   // By default, `vscode.typescript-language-features` is not activated when a user opens *.css in VS Code.
@@ -15,7 +24,6 @@ export async function activate(_context: vscode.ExtensionContext) {
     console.log('[css-modules-kit-vscode] Activating `vscode.typescript-language-features`');
     tsExtension.activate();
   }
-
   // Both vscode.css-language-features extension and tsserver receive "rename" requests for *.css.
   // If more than one Provider receives a "rename" request, VS Code will use one of them.
   // In this case, the extension is used to rename. However, we do not want this.
@@ -29,17 +37,65 @@ export async function activate(_context: vscode.ExtensionContext) {
   // If not disabled, "rename" and "references" will behave in a way the user does not want.
   const cssExtension = vscode.extensions.getExtension('vscode.css-language-features');
   if (cssExtension) {
-    // Temporarily commented out
-    // vscode.window
-    //   .showInformationMessage(
-    //     '"Rename Symbol" and "Find All References" do not work in some cases because the "CSS Language Features" extension is enabled. Disabling the extension will make them work.',
-    //     'Show "CSS Language Features" extension',
-    //   )
-    //   .then((selected) => {
-    //     if (selected) {
-    //       vscode.commands.executeCommand('workbench.extensions.search', '@builtin css-language-features');
-    //     }
-    //   });
+    // Both vscode.css-language-features and tsserver subscribe to LSP requests for .css and return responses.
+    //
+    // For requests like "completion" or "references" the merged results of the two responses are displayed
+    // to the user. However, for certain types of requests like "rename" or "documentLink" the response
+    // from one Language Server takes precedence. Which Language Server is prioritized is determined by scoring.
+    //
+    // - https://github.com/microsoft/vscode/issues/115354
+    //
+    // Limiting the discussion to vscode.css-language-features and tsserver, it seems that
+    // vscode.css-language-features takes precedence. As a result, "rename" and "documentLink"
+    // behave unexpectedly.
+    //
+    // - https://github.com/mizdra/css-modules-kit/issues/121
+    // - Case 1 in https://github.com/mizdra/css-modules-kit/issues/133
+    //
+    // Therefore, in this case, we use the VS Code extension API to intercept "rename" and "documentLink"
+    // requests and redirect them to tsserver. This technique is known as "Request Forwarding".
+    //
+    // - https://code.visualstudio.com/api/language-extensions/embedded-languages#request-forwarding
+    //
+    // Using Request Forwarding, "rename" and "documentLink" now work as expected.
+    vscode.workspace.registerTextDocumentContentProvider(ORIGINAL_SCHEME, {
+      async provideTextDocumentContent(uri) {
+        // `uri.fsPath` is in the format `/path/to/file.module.css.ts`.
+        const actualFilePath = uri.fsPath.slice(0, -3); // Remove the '.ts' extension
+        const actualFileDocument = await vscode.workspace.openTextDocument(actualFilePath);
+        const text = actualFileDocument.getText();
+        return text;
+      },
+    });
+    context.subscriptions.push(
+      vscode.languages.registerRenameProvider(['css'], {
+        provideRenameEdits(document, position, newName, _token) {
+          // NOTE: Executing `executeDocumentRenameProvider` on a virtual text document causes a runtime error. This is probably a bug in vscode.
+          return vscode.commands.executeCommand<vscode.WorkspaceEdit>(
+            'vscode.executeDocumentRenameProvider',
+            vscode.Uri.parse(`${ORIGINAL_SCHEME}://${document.fileName}.ts`),
+            position,
+            newName,
+          );
+        },
+        prepareRename(document, position, _token) {
+          return vscode.commands.executeCommand<RangeOrRangeWithPlaceholder>(
+            'vscode.prepareRename',
+            vscode.Uri.parse(`${ORIGINAL_SCHEME}://${document.fileName}.ts`),
+            position,
+          );
+        },
+      }),
+      vscode.languages.registerDocumentLinkProvider(['css'], {
+        async provideDocumentLinks(document, _token) {
+          // NOTE: Executing `executeDocumentLinkProvider` on a virtual text document, an empty array is always returned. This is probably a bug in vscode.
+          return vscode.commands.executeCommand<vscode.Location[]>(
+            'vscode.executeLinkProvider',
+            vscode.Uri.parse(`${ORIGINAL_SCHEME}://${document.fileName}.ts`),
+          );
+        },
+      }),
+    );
   } else {
     // If vscode.css-language-features extension is disabled, start the customized language server for *.css, *.scss, and *.less.
     // The language server is based on the vscode-css-languageservice, but "rename" and "references" features are disabled.

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -57,7 +57,7 @@ export async function activate(context: vscode.ExtensionContext) {
     //
     // - https://code.visualstudio.com/api/language-extensions/embedded-languages#request-forwarding
     //
-    // Using Request Forwarding, "rename" and "documentLink" now work as expected.
+    // Using Request Forwarding solves the problem of "rename" and "references" requests.
     vscode.workspace.registerTextDocumentContentProvider(ORIGINAL_SCHEME, {
       async provideTextDocumentContent(uri) {
         // `uri.fsPath` is in the format `/path/to/file.module.css.ts`.


### PR DESCRIPTION
ref: #121, Case 1 of #133

Both vscode.css-language-features and tsserver subscribe to LSP requests for .css and return responses.

For requests like "completion" or "references" the merged results of the two responses are displayed to the user. However, for certain types of requests like "rename" or "documentLink" the response from one Language Server takes precedence. Which Language Server is prioritized is determined by scoring.

- https://github.com/microsoft/vscode/issues/115354

Limiting the discussion to vscode.css-language-features and tsserver, it seems that vscode.css-language-features takes precedence. As a result, "rename" and "documentLink" behave unexpectedly.

- https://github.com/mizdra/css-modules-kit/issues/121
- Case 1 in https://github.com/mizdra/css-modules-kit/issues/133

Therefore, in this case, we use the VS Code extension API to intercept "rename" and "documentLink" requests and redirect them to tsserver. This technique is known as "Request Forwarding".

- https://code.visualstudio.com/api/language-extensions/embedded-languages#request-forwarding

Using Request Forwarding solves the problem of "rename" and "references" requests.