### PR TITLE
Definition Context for Hover Info

### DIFF
--- a/.changeset/big-badgers-roll.md
+++ b/.changeset/big-badgers-roll.md
@@ -1,0 +1,6 @@
+---
+'@css-modules-kit/ts-plugin': minor
+'@css-modules-kit/core': minor
+---
+
+feat: support "Definition Preview for Hover"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ https://github.com/user-attachments/assets/df1e2feb-2a1a-4bf5-ae70-1cac36d90409
 </details>
 
 <details>
+<summary>Definition Preview by Hover</summary>
+
+You can preview the definition with <kbd>Command</kbd> + <kbd>Hover</kbd> on macOS and VS Code (key bindings may vary depending on your OS and editor).
+
+https://github.com/user-attachments/assets/8d42acb8-2822-4fe6-89ce-8472c7065b8b
+
+</details>
+
+<details>
 <summary>Automatically update import statements when moving `*.module.css`</summary>
 
 https://github.com/user-attachments/assets/4af168fa-357d-44e1-b010-3053802bf1a2

--- a/packages/core/src/parser/at-value-parser.test.ts
+++ b/packages/core/src/parser/at-value-parser.test.ts
@@ -24,6 +24,18 @@ describe('parseAtValue', () => {
       [
         {
           "atValue": {
+            "declarationLoc": {
+              "end": {
+                "column": 19,
+                "line": 1,
+                "offset": 18,
+              },
+              "start": {
+                "column": 1,
+                "line": 1,
+                "offset": 0,
+              },
+            },
             "loc": {
               "end": {
                 "column": 13,
@@ -43,6 +55,18 @@ describe('parseAtValue', () => {
         },
         {
           "atValue": {
+            "declarationLoc": {
+              "end": {
+                "column": 25,
+                "line": 2,
+                "offset": 44,
+              },
+              "start": {
+                "column": 1,
+                "line": 2,
+                "offset": 20,
+              },
+            },
             "loc": {
               "end": {
                 "column": 20,
@@ -62,6 +86,18 @@ describe('parseAtValue', () => {
         },
         {
           "atValue": {
+            "declarationLoc": {
+              "end": {
+                "column": 14,
+                "line": 3,
+                "offset": 59,
+              },
+              "start": {
+                "column": 1,
+                "line": 3,
+                "offset": 46,
+              },
+            },
             "loc": {
               "end": {
                 "column": 13,
@@ -81,6 +117,18 @@ describe('parseAtValue', () => {
         },
         {
           "atValue": {
+            "declarationLoc": {
+              "end": {
+                "column": 29,
+                "line": 4,
+                "offset": 89,
+              },
+              "start": {
+                "column": 1,
+                "line": 4,
+                "offset": 61,
+              },
+            },
             "loc": {
               "end": {
                 "column": 15,
@@ -100,6 +148,18 @@ describe('parseAtValue', () => {
         },
         {
           "atValue": {
+            "declarationLoc": {
+              "end": {
+                "column": 35,
+                "line": 5,
+                "offset": 125,
+              },
+              "start": {
+                "column": 1,
+                "line": 5,
+                "offset": 91,
+              },
+            },
             "loc": {
               "end": {
                 "column": 15,
@@ -255,6 +315,18 @@ describe('parseAtValue', () => {
         },
         {
           "atValue": {
+            "declarationLoc": {
+              "end": {
+                "column": 28,
+                "line": 9,
+                "offset": 268,
+              },
+              "start": {
+                "column": 2,
+                "line": 9,
+                "offset": 242,
+              },
+            },
             "loc": {
               "end": {
                 "column": 20,

--- a/packages/core/src/parser/at-value-parser.ts
+++ b/packages/core/src/parser/at-value-parser.ts
@@ -6,6 +6,11 @@ interface ValueDeclaration {
   name: string;
   // value: string; // unused
   loc: Location;
+  /**
+   * NOTE: The `declarationLoc` for value declaration does not include the trailing semicolon.
+   * @example `@value white: #fff` has `declarationLoc` as `{ start: { line: 1, column: 1, offset: 0 }, end: { line: 1, column: 19, offset: 18 } }`.
+   */
+  declarationLoc: Location;
 }
 
 interface ValueImportDeclaration {
@@ -149,7 +154,15 @@ export function parseAtValue(atValue: AtRule): ParseAtValueResult {
       column: start.column + name.length,
       offset: start.offset + name.length,
     };
-    const parsedAtValue = { type: 'valueDeclaration', name, loc: { start, end } } as const;
+    const parsedAtValue: ValueDeclaration = {
+      type: 'valueDeclaration',
+      name,
+      loc: { start, end },
+      declarationLoc: {
+        start: atValue.source!.start!,
+        end: atValue.positionBy({ index: atValue.toString().length }),
+      },
+    } as const;
     return { atValue: parsedAtValue, diagnostics };
   }
   diagnostics.push({

--- a/packages/core/src/parser/css-module-parser.test.ts
+++ b/packages/core/src/parser/css-module-parser.test.ts
@@ -33,6 +33,18 @@ describe('parseCSSModule', () => {
           "fileName": "/test.module.css",
           "localTokens": [
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 10,
+                  "line": 1,
+                  "offset": 9,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 7,
@@ -48,6 +60,18 @@ describe('parseCSSModule', () => {
               "name": "basic",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 14,
+                  "line": 2,
+                  "offset": 23,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 2,
+                  "offset": 10,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 11,
@@ -63,6 +87,18 @@ describe('parseCSSModule', () => {
               "name": "cascading",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 14,
+                  "line": 3,
+                  "offset": 37,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 3,
+                  "offset": 24,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 11,
@@ -78,6 +114,18 @@ describe('parseCSSModule', () => {
               "name": "cascading",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 19,
+                  "line": 4,
+                  "offset": 56,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 4,
+                  "offset": 38,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 16,
@@ -93,6 +141,18 @@ describe('parseCSSModule', () => {
               "name": "pseudo_class_1",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 25,
+                  "line": 5,
+                  "offset": 81,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 5,
+                  "offset": 57,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 16,
@@ -108,6 +168,18 @@ describe('parseCSSModule', () => {
               "name": "pseudo_class_2",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 25,
+                  "line": 6,
+                  "offset": 106,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 6,
+                  "offset": 82,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 21,
@@ -123,6 +195,18 @@ describe('parseCSSModule', () => {
               "name": "pseudo_class_3",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 44,
+                  "line": 7,
+                  "offset": 150,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 7,
+                  "offset": 107,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 21,
@@ -138,6 +222,18 @@ describe('parseCSSModule', () => {
               "name": "multiple_selector_1",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 44,
+                  "line": 7,
+                  "offset": 150,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 7,
+                  "offset": 107,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 41,
@@ -153,6 +249,18 @@ describe('parseCSSModule', () => {
               "name": "multiple_selector_2",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 33,
+                  "line": 8,
+                  "offset": 183,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 8,
+                  "offset": 151,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 14,
@@ -168,6 +276,18 @@ describe('parseCSSModule', () => {
               "name": "combinator_1",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 33,
+                  "line": 8,
+                  "offset": 183,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 8,
+                  "offset": 151,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 30,
@@ -183,6 +303,18 @@ describe('parseCSSModule', () => {
               "name": "combinator_2",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 16,
+                  "line": 11,
+                  "offset": 268,
+                },
+                "start": {
+                  "column": 5,
+                  "line": 11,
+                  "offset": 257,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 13,
@@ -198,6 +330,18 @@ describe('parseCSSModule', () => {
               "name": "at_rule",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 38,
+                  "line": 14,
+                  "offset": 312,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 14,
+                  "offset": 275,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 17,
@@ -213,6 +357,18 @@ describe('parseCSSModule', () => {
               "name": "selector_list_1",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 38,
+                  "line": 14,
+                  "offset": 312,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 14,
+                  "offset": 275,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 35,
@@ -228,6 +384,18 @@ describe('parseCSSModule', () => {
               "name": "selector_list_2",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 20,
+                  "line": 15,
+                  "offset": 332,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 15,
+                  "offset": 313,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 16,
@@ -393,6 +561,18 @@ describe('parseCSSModule', () => {
           "fileName": "/test.module.css",
           "localTokens": [
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 18,
+                  "line": 1,
+                  "offset": 17,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 15,
@@ -534,6 +714,18 @@ describe('parseCSSModule', () => {
           "fileName": "/test.module.css",
           "localTokens": [
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 6,
+                  "line": 1,
+                  "offset": 5,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 3,

--- a/packages/core/src/parser/css-module-parser.test.ts
+++ b/packages/core/src/parser/css-module-parser.test.ts
@@ -411,6 +411,18 @@ describe('parseCSSModule', () => {
               "name": "local_1",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 22,
+                  "line": 16,
+                  "offset": 354,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 16,
+                  "offset": 333,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 13,

--- a/packages/core/src/parser/css-module-parser.ts
+++ b/packages/core/src/parser/css-module-parser.ts
@@ -49,7 +49,7 @@ function collectTokens(ast: Root) {
       allDiagnostics.push(...diagnostics);
       if (atValue === undefined) return;
       if (atValue.type === 'valueDeclaration') {
-        localTokens.push({ name: atValue.name, loc: atValue.loc });
+        localTokens.push({ name: atValue.name, loc: atValue.loc, declarationLoc: atValue.declarationLoc });
       } else if (atValue.type === 'valueImportDeclaration') {
         tokenImporters.push({ ...atValue, type: 'value' });
       }

--- a/packages/core/src/parser/rule-parser.test.ts
+++ b/packages/core/src/parser/rule-parser.test.ts
@@ -231,6 +231,18 @@ describe('parseRule', () => {
         {
           "classSelectors": [
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 10,
+                  "line": 1,
+                  "offset": 9,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 7,
@@ -251,6 +263,18 @@ describe('parseRule', () => {
         {
           "classSelectors": [
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 14,
+                  "line": 2,
+                  "offset": 23,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 2,
+                  "offset": 10,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 11,
@@ -271,6 +295,18 @@ describe('parseRule', () => {
         {
           "classSelectors": [
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 14,
+                  "line": 3,
+                  "offset": 37,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 3,
+                  "offset": 24,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 11,
@@ -291,6 +327,18 @@ describe('parseRule', () => {
         {
           "classSelectors": [
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 19,
+                  "line": 4,
+                  "offset": 56,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 4,
+                  "offset": 38,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 16,
@@ -311,6 +359,18 @@ describe('parseRule', () => {
         {
           "classSelectors": [
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 25,
+                  "line": 5,
+                  "offset": 81,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 5,
+                  "offset": 57,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 16,
@@ -331,6 +391,18 @@ describe('parseRule', () => {
         {
           "classSelectors": [
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 25,
+                  "line": 6,
+                  "offset": 106,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 6,
+                  "offset": 82,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 21,
@@ -351,6 +423,18 @@ describe('parseRule', () => {
         {
           "classSelectors": [
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 44,
+                  "line": 7,
+                  "offset": 150,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 7,
+                  "offset": 107,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 21,
@@ -366,6 +450,18 @@ describe('parseRule', () => {
               "name": "multiple_selector_1",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 44,
+                  "line": 7,
+                  "offset": 150,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 7,
+                  "offset": 107,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 41,
@@ -386,6 +482,18 @@ describe('parseRule', () => {
         {
           "classSelectors": [
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 33,
+                  "line": 8,
+                  "offset": 183,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 8,
+                  "offset": 151,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 14,
@@ -401,6 +509,18 @@ describe('parseRule', () => {
               "name": "combinator_1",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 33,
+                  "line": 8,
+                  "offset": 183,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 8,
+                  "offset": 151,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 30,
@@ -421,6 +541,18 @@ describe('parseRule', () => {
         {
           "classSelectors": [
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 16,
+                  "line": 11,
+                  "offset": 268,
+                },
+                "start": {
+                  "column": 5,
+                  "line": 11,
+                  "offset": 257,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 13,
@@ -441,6 +573,18 @@ describe('parseRule', () => {
         {
           "classSelectors": [
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 38,
+                  "line": 14,
+                  "offset": 312,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 14,
+                  "offset": 275,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 17,
@@ -456,6 +600,18 @@ describe('parseRule', () => {
               "name": "selector_list_1",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 38,
+                  "line": 14,
+                  "offset": 312,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 14,
+                  "offset": 275,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 35,
@@ -476,6 +632,18 @@ describe('parseRule', () => {
         {
           "classSelectors": [
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 31,
+                  "line": 15,
+                  "offset": 343,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 15,
+                  "offset": 313,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 27,
@@ -496,6 +664,18 @@ describe('parseRule', () => {
         {
           "classSelectors": [
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 24,
+                  "line": 18,
+                  "offset": 400,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 16,
+                  "offset": 344,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 16,
@@ -511,6 +691,18 @@ describe('parseRule', () => {
               "name": "with_newline_1",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 24,
+                  "line": 18,
+                  "offset": 400,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 16,
+                  "offset": 344,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 16,
@@ -526,6 +718,18 @@ describe('parseRule', () => {
               "name": "with_newline_2",
             },
             {
+              "declarationLoc": {
+                "end": {
+                  "column": 24,
+                  "line": 18,
+                  "offset": 400,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 16,
+                  "offset": 344,
+                },
+              },
               "loc": {
                 "end": {
                   "column": 20,
@@ -677,6 +881,18 @@ describe('parseRule', () => {
           {
             "classSelectors": [
               {
+                "declarationLoc": {
+                  "end": {
+                    "column": 18,
+                    "line": 1,
+                    "offset": 17,
+                  },
+                  "start": {
+                    "column": 1,
+                    "line": 1,
+                    "offset": 0,
+                  },
+                },
                 "loc": {
                   "end": {
                     "column": 15,
@@ -708,6 +924,18 @@ describe('parseRule', () => {
           {
             "classSelectors": [
               {
+                "declarationLoc": {
+                  "end": {
+                    "column": 20,
+                    "line": 2,
+                    "offset": 37,
+                  },
+                  "start": {
+                    "column": 1,
+                    "line": 2,
+                    "offset": 18,
+                  },
+                },
                 "loc": {
                   "end": {
                     "column": 17,

--- a/packages/core/src/parser/rule-parser.ts
+++ b/packages/core/src/parser/rule-parser.ts
@@ -104,8 +104,16 @@ function collectLocalClassNames(rule: Rule, root: selectorParser.Root): CollectR
 interface ClassSelector {
   /** The class name. It does not include the leading dot. */
   name: string;
-  /** The location of the class selector. */
+  /**
+   * The location of the class selector.
+   * @example `.a {}` has `loc` as `{ start: { line: 1, column: 2, offset: 1 }, end: { line: 1, column: 3, offset: 2 } }`.
+   */
   loc: Location;
+  /**
+   * The location of the declaration of the token in the source file.
+   * @example `.a {}` has `declarationLoc` as `{ start: { line: 1, column: 1, offset: 0 }, end: { line: 1, column: 6, offset: 5 } }`.
+   */
+  declarationLoc: Location;
 }
 
 interface ParseRuleResult {
@@ -119,7 +127,7 @@ interface ParseRuleResult {
 export function parseRule(rule: Rule): ParseRuleResult {
   const root = selectorParser().astSync(rule);
   const result = collectLocalClassNames(rule, root);
-  const classSelectors = result.classNames.map((className) => {
+  const classSelectors: ClassSelector[] = result.classNames.map((className) => {
     // If `rule` is `.a, .b { color: red; }` and `className` is `.b`,
     // `rule.source` is `{ start: { line: 1, column: 1 }, end: { line: 1, column: 22 } }`
     // And `className.source` is `{ start: { line: 1, column: 5 }, end: { line: 1, column: 6 } }`.
@@ -137,6 +145,7 @@ export function parseRule(rule: Rule): ParseRuleResult {
     return {
       name: className.value,
       loc: { start, end },
+      declarationLoc: { start: rule.source!.start!, end: rule.positionBy({ index: rule.toString().length }) },
     };
   });
   return { classSelectors, diagnostics: result.diagnostics };

--- a/packages/core/src/type.ts
+++ b/packages/core/src/type.ts
@@ -34,6 +34,8 @@ export interface Token {
   name: string;
   /** The location of the token in the source file. */
   loc: Location;
+  /** The location of the declaration of the token in the source file. */
+  declarationLoc?: Location;
 }
 
 /**

--- a/packages/ts-plugin/e2e/feature/go-to-definition.test.ts
+++ b/packages/ts-plugin/e2e/feature/go-to-definition.test.ts
@@ -147,7 +147,13 @@ describe('Go to Definition', async () => {
       line: 4,
       offset: 8,
       expected: [
-        { file: formatPath(iff.paths['a.module.css']), start: { line: 6, offset: 8 }, end: { line: 6, offset: 11 } },
+        {
+          file: formatPath(iff.paths['a.module.css']),
+          start: { line: 6, offset: 8 },
+          end: { line: 6, offset: 11 },
+          contextStart: { line: 6, offset: 1 },
+          contextEnd: { line: 6, offset: 16 },
+        },
       ],
     },
     {
@@ -182,7 +188,13 @@ describe('Go to Definition', async () => {
           contextStart: { line: 2, offset: 8 },
           contextEnd: { line: 2, offset: 11 },
         },
-        { file: formatPath(iff.paths['c.module.css']), start: { line: 1, offset: 8 }, end: { line: 1, offset: 11 } },
+        {
+          file: formatPath(iff.paths['c.module.css']),
+          start: { line: 1, offset: 8 },
+          end: { line: 1, offset: 11 },
+          contextStart: { line: 1, offset: 1 },
+          contextEnd: { line: 1, offset: 16 },
+        },
       ],
     },
     {
@@ -202,7 +214,13 @@ describe('Go to Definition', async () => {
           contextStart: { line: 2, offset: 8 },
           contextEnd: { line: 2, offset: 11 },
         },
-        { file: formatPath(iff.paths['c.module.css']), start: { line: 1, offset: 8 }, end: { line: 1, offset: 11 } },
+        {
+          file: formatPath(iff.paths['c.module.css']),
+          start: { line: 1, offset: 8 },
+          end: { line: 1, offset: 11 },
+          contextStart: { line: 1, offset: 1 },
+          contextEnd: { line: 1, offset: 16 },
+        },
       ],
     },
     {
@@ -222,7 +240,13 @@ describe('Go to Definition', async () => {
           contextStart: { line: 2, offset: 20 },
           contextEnd: { line: 2, offset: 16 },
         },
-        { file: formatPath(iff.paths['c.module.css']), start: { line: 2, offset: 8 }, end: { line: 2, offset: 11 } },
+        {
+          file: formatPath(iff.paths['c.module.css']),
+          start: { line: 2, offset: 8 },
+          end: { line: 2, offset: 11 },
+          contextStart: { line: 2, offset: 1 },
+          contextEnd: { line: 2, offset: 16 },
+        },
       ],
     },
     {
@@ -242,7 +266,13 @@ describe('Go to Definition', async () => {
           contextStart: { line: 2, offset: 20 },
           contextEnd: { line: 2, offset: 16 },
         },
-        { file: formatPath(iff.paths['c.module.css']), start: { line: 2, offset: 8 }, end: { line: 2, offset: 11 } },
+        {
+          file: formatPath(iff.paths['c.module.css']),
+          start: { line: 2, offset: 8 },
+          end: { line: 2, offset: 11 },
+          contextStart: { line: 2, offset: 1 },
+          contextEnd: { line: 2, offset: 16 },
+        },
       ],
     },
     {
@@ -251,7 +281,13 @@ describe('Go to Definition', async () => {
       line: 2,
       offset: 13,
       expected: [
-        { file: formatPath(iff.paths['c.module.css']), start: { line: 2, offset: 8 }, end: { line: 2, offset: 11 } },
+        {
+          file: formatPath(iff.paths['c.module.css']),
+          start: { line: 2, offset: 8 },
+          end: { line: 2, offset: 11 },
+          contextStart: { line: 2, offset: 1 },
+          contextEnd: { line: 2, offset: 16 },
+        },
       ],
     },
     {

--- a/packages/ts-plugin/e2e/feature/go-to-definition.test.ts
+++ b/packages/ts-plugin/e2e/feature/go-to-definition.test.ts
@@ -88,7 +88,13 @@ describe('Go to Definition', async () => {
       line: 2,
       offset: 8,
       expected: [
-        { file: formatPath(iff.paths['a.module.css']), start: { line: 3, offset: 2 }, end: { line: 3, offset: 5 } },
+        {
+          file: formatPath(iff.paths['a.module.css']),
+          start: { line: 3, offset: 2 },
+          end: { line: 3, offset: 5 },
+          contextStart: { line: 3, offset: 1 },
+          contextEnd: { line: 3, offset: 21 },
+        },
       ],
     },
     {
@@ -97,8 +103,20 @@ describe('Go to Definition', async () => {
       line: 3,
       offset: 8,
       expected: [
-        { file: formatPath(iff.paths['a.module.css']), start: { line: 5, offset: 2 }, end: { line: 5, offset: 5 } },
-        { file: formatPath(iff.paths['a.module.css']), start: { line: 4, offset: 2 }, end: { line: 4, offset: 5 } },
+        {
+          file: formatPath(iff.paths['a.module.css']),
+          start: { line: 4, offset: 2 },
+          end: { line: 4, offset: 5 },
+          contextStart: { line: 4, offset: 1 },
+          contextEnd: { line: 4, offset: 21 },
+        },
+        {
+          file: formatPath(iff.paths['a.module.css']),
+          start: { line: 5, offset: 2 },
+          end: { line: 5, offset: 5 },
+          contextStart: { line: 4, offset: 1 },
+          contextEnd: { line: 4, offset: 21 },
+        },
       ],
     },
     {
@@ -107,8 +125,20 @@ describe('Go to Definition', async () => {
       line: 4,
       offset: 2,
       expected: [
-        { file: formatPath(iff.paths['a.module.css']), start: { line: 5, offset: 2 }, end: { line: 5, offset: 5 } },
-        { file: formatPath(iff.paths['a.module.css']), start: { line: 4, offset: 2 }, end: { line: 4, offset: 5 } },
+        {
+          file: formatPath(iff.paths['a.module.css']),
+          start: { line: 4, offset: 2 },
+          end: { line: 4, offset: 5 },
+          contextStart: { line: 4, offset: 1 },
+          contextEnd: { line: 4, offset: 21 },
+        },
+        {
+          file: formatPath(iff.paths['a.module.css']),
+          start: { line: 5, offset: 2 },
+          end: { line: 5, offset: 5 },
+          contextStart: { line: 4, offset: 1 },
+          contextEnd: { line: 4, offset: 21 },
+        },
       ],
     },
     {
@@ -126,7 +156,13 @@ describe('Go to Definition', async () => {
       line: 5,
       offset: 8,
       expected: [
-        { file: formatPath(iff.paths['b.module.css']), start: { line: 1, offset: 2 }, end: { line: 1, offset: 5 } },
+        {
+          file: formatPath(iff.paths['b.module.css']),
+          start: { line: 1, offset: 2 },
+          end: { line: 1, offset: 5 },
+          contextStart: { line: 1, offset: 1 },
+          contextEnd: { line: 1, offset: 21 },
+        },
       ],
     },
     {
@@ -139,7 +175,13 @@ describe('Go to Definition', async () => {
       //   { file: formatPath(iff.paths['c.module.css']), start: { line: 1, offset: 8 }, end: { line: 1, offset: 11 } },
       // ],
       expected: [
-        { file: formatPath(iff.paths['a.module.css']), start: { line: 2, offset: 8 }, end: { line: 2, offset: 11 } },
+        {
+          file: formatPath(iff.paths['a.module.css']),
+          start: { line: 2, offset: 8 },
+          end: { line: 2, offset: 11 },
+          contextStart: { line: 2, offset: 8 },
+          contextEnd: { line: 2, offset: 11 },
+        },
         { file: formatPath(iff.paths['c.module.css']), start: { line: 1, offset: 8 }, end: { line: 1, offset: 11 } },
       ],
     },
@@ -153,7 +195,13 @@ describe('Go to Definition', async () => {
       //   { file: formatPath(iff.paths['c.module.css']), start: { line: 1, offset: 8 }, end: { line: 1, offset: 11 } },
       // ],
       expected: [
-        { file: formatPath(iff.paths['a.module.css']), start: { line: 2, offset: 8 }, end: { line: 2, offset: 11 } },
+        {
+          file: formatPath(iff.paths['a.module.css']),
+          start: { line: 2, offset: 8 },
+          end: { line: 2, offset: 11 },
+          contextStart: { line: 2, offset: 8 },
+          contextEnd: { line: 2, offset: 11 },
+        },
         { file: formatPath(iff.paths['c.module.css']), start: { line: 1, offset: 8 }, end: { line: 1, offset: 11 } },
       ],
     },
@@ -167,7 +215,13 @@ describe('Go to Definition', async () => {
       //   { file: formatPath(iff.paths['c.module.css']), start: { line: 2, offset: 8 }, end: { line: 2, offset: 11 } },
       // ],
       expected: [
-        { file: formatPath(iff.paths['a.module.css']), start: { line: 2, offset: 20 }, end: { line: 2, offset: 27 } },
+        {
+          file: formatPath(iff.paths['a.module.css']),
+          start: { line: 2, offset: 20 },
+          end: { line: 2, offset: 27 },
+          contextStart: { line: 2, offset: 20 },
+          contextEnd: { line: 2, offset: 16 },
+        },
         { file: formatPath(iff.paths['c.module.css']), start: { line: 2, offset: 8 }, end: { line: 2, offset: 11 } },
       ],
     },
@@ -181,7 +235,13 @@ describe('Go to Definition', async () => {
       //   { file: formatPath(iff.paths['c.module.css']), start: { line: 2, offset: 8 }, end: { line: 2, offset: 11 } },
       // ],
       expected: [
-        { file: formatPath(iff.paths['a.module.css']), start: { line: 2, offset: 20 }, end: { line: 2, offset: 27 } },
+        {
+          file: formatPath(iff.paths['a.module.css']),
+          start: { line: 2, offset: 20 },
+          end: { line: 2, offset: 27 },
+          contextStart: { line: 2, offset: 20 },
+          contextEnd: { line: 2, offset: 16 },
+        },
         { file: formatPath(iff.paths['c.module.css']), start: { line: 2, offset: 8 }, end: { line: 2, offset: 11 } },
       ],
     },

--- a/packages/ts-plugin/e2e/invalid-syntax.test.ts
+++ b/packages/ts-plugin/e2e/invalid-syntax.test.ts
@@ -37,6 +37,8 @@ describe('handle invalid syntax CSS without crashing', async () => {
         file: formatPath(iff.paths['a.module.css']),
         start: { line: 1, offset: 2 },
         end: { line: 1, offset: 5 },
+        contextStart: { line: 1, offset: 1 },
+        contextEnd: { line: 1, offset: 21 },
       },
     ];
     expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(normalizeDefinitions(expected));

--- a/packages/ts-plugin/e2e/test-util/tsserver.ts
+++ b/packages/ts-plugin/e2e/test-util/tsserver.ts
@@ -90,6 +90,8 @@ type SimplifiedDefinitionInfo = {
   file: string;
   start: ts.server.protocol.Location;
   end: ts.server.protocol.Location;
+  contextStart?: ts.server.protocol.Location;
+  contextEnd?: ts.server.protocol.Location;
 };
 
 export function normalizeDefinitions(definitions: readonly SimplifiedDefinitionInfo[]): SimplifiedDefinitionInfo[] {
@@ -99,6 +101,8 @@ export function normalizeDefinitions(definitions: readonly SimplifiedDefinitionI
         file: formatPath(definition.file),
         start: definition.start,
         end: definition.end,
+        ...('contextStart' in definition ? { contextStart: definition.contextStart } : {}),
+        ...('contextEnd' in definition ? { contextEnd: definition.contextEnd } : {}),
       };
     })
     .toSorted((a, b) => {

--- a/packages/ts-plugin/src/language-service/feature/definition-and-bound-span.ts
+++ b/packages/ts-plugin/src/language-service/feature/definition-and-bound-span.ts
@@ -1,0 +1,28 @@
+import type { Language } from '@volar/language-core';
+import type ts from 'typescript';
+import { CMK_DATA_KEY, isCSSModuleScript } from '../../language-plugin.js';
+
+export function getDefinitionAndBoundSpan(
+  language: Language<string>,
+  languageService: ts.LanguageService,
+): ts.LanguageService['getDefinitionAndBoundSpan'] {
+  return (...args) => {
+    const result = languageService.getDefinitionAndBoundSpan(...args);
+    if (!result) return;
+    if (!result.definitions) return result;
+    for (const def of result.definitions) {
+      const script = language.scripts.get(def.fileName);
+      if (isCSSModuleScript(script)) {
+        const cssModule = script.generated.root[CMK_DATA_KEY].cssModule;
+        const token = cssModule.localTokens.find((t) => t.name === def.name);
+        if (token?.declarationLoc) {
+          def.contextSpan = {
+            start: token.declarationLoc.start.offset,
+            length: token.declarationLoc.end.offset - token.declarationLoc.start.offset,
+          };
+        }
+      }
+    }
+    return result;
+  };
+}

--- a/packages/ts-plugin/src/language-service/proxy.ts
+++ b/packages/ts-plugin/src/language-service/proxy.ts
@@ -5,6 +5,7 @@ import type ts from 'typescript';
 import { CMK_DATA_KEY, isCSSModuleScript } from '../language-plugin.js';
 import { getCodeFixesAtPosition } from './feature/code-fix.js';
 import { getCompletionEntryDetails, getCompletionsAtPosition } from './feature/completion.js';
+import { getDefinitionAndBoundSpan } from './feature/definition-and-bound-span.js';
 import { getApplicableRefactors, getEditsForRefactor } from './feature/refactor.js';
 import { getSemanticDiagnostics } from './feature/semantic-diagnostic.js';
 import { getSyntacticDiagnostics } from './feature/syntactic-diagnostic.js';
@@ -50,6 +51,7 @@ export function proxyLanguageService(
   proxy.getCompletionsAtPosition = getCompletionsAtPosition(languageService, config);
   proxy.getCompletionEntryDetails = getCompletionEntryDetails(languageService, resolver, config);
   proxy.getCodeFixesAtPosition = getCodeFixesAtPosition(language, languageService, project, resolver, config);
+  proxy.getDefinitionAndBoundSpan = getDefinitionAndBoundSpan(language, languageService);
 
   return proxy;
 }


### PR DESCRIPTION
ref: #135, #179

With this PR, users will be able to preview token definitions in VS Code using Cmd + Hover.

This feature is implemented by setting the location of the token definition in the `contextStart`/`contextEnd` properties of the `definitionAndBoundSpan` response.

## Preview

https://github.com/user-attachments/assets/45aba05b-40b9-4d52-aff5-68c8be862dc9

## Pros

- The `contextStart`/`contextEnd` properties of the `definitionAndBoundSpan` response are the standard way to preview definitions.
  - It should work seamlessly with other editors besides VS Code.
- VS Code automatically strips definition indentation.
  - <img width="325" alt="image" src="https://github.com/user-attachments/assets/24e41048-9151-4308-a083-4202b86b8b08" />
  - https://github.com/microsoft/vscode/blob/dd48c7f264782fc16486381e8792f79a3f7a19fa/src/vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.ts#L237
  - #179 cannot do this.
- The implementation is simple.
  - Unlike #179, there is no need to change the `.d.ts` format.
- Value declarations (`@value <name>: <value>`) can also be previewed correctly.
  - #179 cannot do this.

## Cons

- In VS Code, definitions cannot be previewed as easily as in #179.
  - Hover alone does not trigger the preview. The Cmd key must be pressed. 
- In VS Code, hovering without the Cmd key and then pressing the Cmd key after hovering does not preview the definition.
  - https://github.com/user-attachments/assets/5c376c0b-473c-455a-938f-991f6ac0b2b2
  - This is a VS Code bug: https://github.com/microsoft/vscode/issues/167781
