### PR TITLE
Revert "Avoid LSP request conflicts with Request Forwarding"

### DIFF
--- a/.changeset/hip-buses-design.md
+++ b/.changeset/hip-buses-design.md
@@ -1,0 +1,5 @@
+---
+'css-modules-kit-vscode': patch
+---
+
+chore: revert "Avoid LSP request conflicts with Request Forwarding"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,7 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode",
         "--profile-temp",
+        "--disable-extension=vscode.css-language-features",
         "--skip-welcome",
         "--folder-uri=${workspaceFolder}/example",
         "${workspaceFolder}/example/src/index.tsx"

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -5,16 +5,7 @@ import * as lsp from 'vscode-languageclient/node';
 
 let client: lsp.BaseLanguageClient;
 
-const ORIGINAL_SCHEME = 'css-modules-kit';
-
-type RangeOrRangeWithPlaceholder =
-  | vscode.Range
-  | {
-      range: vscode.Range;
-      placeholder: string;
-    };
-
-export async function activate(context: vscode.ExtensionContext) {
+export async function activate(_context: vscode.ExtensionContext) {
   console.log('[css-modules-kit-vscode] Activated');
 
   // By default, `vscode.typescript-language-features` is not activated when a user opens *.css in VS Code.
@@ -24,6 +15,7 @@ export async function activate(context: vscode.ExtensionContext) {
     console.log('[css-modules-kit-vscode] Activating `vscode.typescript-language-features`');
     tsExtension.activate();
   }
+
   // Both vscode.css-language-features extension and tsserver receive "rename" requests for *.css.
   // If more than one Provider receives a "rename" request, VS Code will use one of them.
   // In this case, the extension is used to rename. However, we do not want this.
@@ -37,71 +29,17 @@ export async function activate(context: vscode.ExtensionContext) {
   // If not disabled, "rename" and "references" will behave in a way the user does not want.
   const cssExtension = vscode.extensions.getExtension('vscode.css-language-features');
   if (cssExtension) {
-    // Both vscode.css-language-features and tsserver subscribe to LSP requests for .css and return responses.
-    //
-    // For requests like "completion" or "references" the merged results of the two responses are displayed
-    // to the user. However, for certain types of requests like "rename" or "documentLink" the response
-    // from one Language Server takes precedence. Which Language Server is prioritized is determined by scoring.
-    //
-    // - https://github.com/microsoft/vscode/issues/115354
-    //
-    // Limiting the discussion to vscode.css-language-features and tsserver, it seems that
-    // vscode.css-language-features takes precedence. As a result, "rename" and "documentLink"
-    // behave unexpectedly.
-    //
-    // - https://github.com/mizdra/css-modules-kit/issues/121
-    // - Case 1 in https://github.com/mizdra/css-modules-kit/issues/133
-    //
-    // Therefore, in this case, we use the VS Code extension API to intercept "rename" and "documentLink"
-    // requests and redirect them to tsserver. This technique is known as "Request Forwarding".
-    //
-    // - https://code.visualstudio.com/api/language-extensions/embedded-languages#request-forwarding
-    //
-    // Using Request Forwarding solves the problem of "rename" and "references" requests.
-    vscode.workspace.registerTextDocumentContentProvider(ORIGINAL_SCHEME, {
-      async provideTextDocumentContent(uri) {
-        // `uri.fsPath` is in the format `/path/to/file.module.css.ts`.
-        const actualFilePath = uri.fsPath.slice(0, -3); // Remove the '.ts' extension
-        const actualFileDocument = await vscode.workspace.openTextDocument(actualFilePath);
-        const text = actualFileDocument.getText();
-        return text;
-      },
-    });
-    context.subscriptions.push(
-      vscode.languages.registerRenameProvider(
-        { language: 'css' },
-        {
-          provideRenameEdits(document, position, newName, _token) {
-            // NOTE: Executing `executeDocumentRenameProvider` on a virtual text document causes a runtime error. This is probably a bug in vscode.
-            return vscode.commands.executeCommand<vscode.WorkspaceEdit>(
-              'vscode.executeDocumentRenameProvider',
-              vscode.Uri.parse(`${ORIGINAL_SCHEME}://${document.fileName}.ts`),
-              position,
-              newName,
-            );
-          },
-          prepareRename(document, position, _token) {
-            return vscode.commands.executeCommand<RangeOrRangeWithPlaceholder>(
-              'vscode.prepareRename',
-              vscode.Uri.parse(`${ORIGINAL_SCHEME}://${document.fileName}.ts`),
-              position,
-            );
-          },
-        },
-      ),
-      vscode.languages.registerDocumentLinkProvider(
-        { language: 'css' },
-        {
-          async provideDocumentLinks(document, _token) {
-            // NOTE: Executing `executeDocumentLinkProvider` on a virtual text document, an empty array is always returned. This is probably a bug in vscode.
-            return vscode.commands.executeCommand<vscode.Location[]>(
-              'vscode.executeLinkProvider',
-              vscode.Uri.parse(`${ORIGINAL_SCHEME}://${document.fileName}.ts`),
-            );
-          },
-        },
-      ),
-    );
+    // Temporarily commented out
+    // vscode.window
+    //   .showInformationMessage(
+    //     '"Rename Symbol" and "Find All References" do not work in some cases because the "CSS Language Features" extension is enabled. Disabling the extension will make them work.',
+    //     'Show "CSS Language Features" extension',
+    //   )
+    //   .then((selected) => {
+    //     if (selected) {
+    //       vscode.commands.executeCommand('workbench.extensions.search', '@builtin css-language-features');
+    //     }
+    //   });
   } else {
     // If vscode.css-language-features extension is disabled, start the customized language server for *.css, *.scss, and *.less.
     // The language server is based on the vscode-css-languageservice, but "rename" and "references" features are disabled.


### PR DESCRIPTION
Reverts mizdra/css-modules-kit#190

Even when using Request Forwarding, it seems that the CSS Language Server still catches requests first. Since we cannot resolve the LSP request conflict, we will revert this.

I plan to revisit this issue at a later date. The hack for Vue.js Language Tool may be useful for it.

- https://github.com/vuejs/language-tools/issues/5261#issuecomment-2857145224