### PR TITLE
fix(ts-plugin): correct the language ID of the DTS virtual code

### DIFF
--- a/packages/ts-plugin/src/language-plugin.ts
+++ b/packages/ts-plugin/src/language-plugin.ts
@@ -61,7 +61,7 @@ export function createCSSLanguagePlugin(
       );
       return {
         id: 'main',
-        languageId: LANGUAGE_ID,
+        languageId: 'typescript',
         snapshot: {
           getText: (start, end) => text.slice(start, end),
           getLength: () => text.length,


### PR DESCRIPTION
In the context of Volar, the languageId of the virtual code should be used to represent the language of the virtual code rather than the language of the source code.

This will cause errors in language server, but there will be no problem in TS plugin.