### PR TITLE
Update bundled ts-plugin version in vscode

### DIFF
--- a/.changeset/kind-cities-cross.md
+++ b/.changeset/kind-cities-cross.md
@@ -1,0 +1,5 @@
+---
+'css-modules-kit-vscode': minor
+---
+
+deps: update bundled ts-plugin version


### PR DESCRIPTION
ref: #251

`vscode` package bundles `ts-plugin` package. Therefore, if you update `ts-plugin`, we must also update `vscode`.