### PR TITLE
Add `wildcardDirectories` in `CMKConfig`

### DIFF
--- a/.changeset/crazy-baboons-share.md
+++ b/.changeset/crazy-baboons-share.md
@@ -1,0 +1,5 @@
+---
+'@css-modules-kit/core': minor
+---
+
+feat: add `wildcardDirectories` in `CMKConfig`

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -50,6 +50,7 @@ describe('readTsConfigFile', () => {
       compilerOptions: expect.objectContaining({
         module: ts.ModuleKind.ESNext,
       }),
+      wildcardDirectories: [{ fileName: iff.join('src'), recursive: true }],
       diagnostics: [],
     });
   });
@@ -75,6 +76,7 @@ describe('readTsConfigFile', () => {
         arbitraryExtensions: true,
       },
       compilerOptions: expect.any(Object),
+      wildcardDirectories: [{ fileName: iff.join('src'), recursive: true }],
       diagnostics: [],
     });
   });
@@ -105,6 +107,7 @@ describe('readTsConfigFile', () => {
       compilerOptions: expect.objectContaining({
         module: undefined,
       }),
+      wildcardDirectories: [{ fileName: iff.join('src'), recursive: true }],
       diagnostics: [
         {
           category: 'error',
@@ -258,6 +261,28 @@ describe('readTsConfigFile', () => {
         dtsOutDir: 'generated/cmk',
         arbitraryExtensions: true,
       });
+    });
+  });
+  describe('wildcardDirectories', () => {
+    test('set root directory if "include" is missing', async () => {
+      const iff = await createIFF({
+        'tsconfig.json': '{}',
+      });
+      expect(readTsConfigFile(iff.rootDir).wildcardDirectories).toEqual([{ fileName: iff.rootDir, recursive: true }]);
+    });
+    test('non-recursive "include" pattern has `recursive === false`', async () => {
+      const iff = await createIFF({
+        'tsconfig.json': dedent`
+          {
+            "include": ["src1", "src2/**/*", "src3/*"]
+          }
+        `,
+      });
+      expect(readTsConfigFile(iff.rootDir).wildcardDirectories).toEqual([
+        { fileName: iff.join('src1'), recursive: true },
+        { fileName: iff.join('src2'), recursive: true },
+        { fileName: iff.join('src3'), recursive: false },
+      ]);
     });
   });
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -58,6 +58,8 @@ export interface CMKConfig {
   basePath: string;
   configFileName: string;
   compilerOptions: ts.CompilerOptions;
+  /** The directories to watch when watch mode is enabled. */
+  wildcardDirectories: { fileName: string; recursive: boolean }[];
   /** The diagnostics that occurred while reading the config file. */
   diagnostics: Diagnostic[];
 }
@@ -184,6 +186,7 @@ export function readTsConfigFile(project: string): {
   configFileName: string;
   config: UnnormalizedRawConfig;
   compilerOptions: ts.CompilerOptions;
+  wildcardDirectories: { fileName: string; recursive: boolean }[];
   diagnostics: Diagnostic[];
 } {
   const configFileName = findTsConfigFile(project);
@@ -234,6 +237,10 @@ export function readTsConfigFile(project: string): {
   return {
     configFileName,
     compilerOptions: parsedCommandLine.options,
+    wildcardDirectories: Object.entries(parsedCommandLine.wildcardDirectories ?? {}).map(([fileName, flags]) => ({
+      fileName,
+      recursive: (flags & ts.WatchDirectoryFlags.Recursive) !== 0,
+    })),
     ...parsedRawData,
   };
 }
@@ -247,7 +254,7 @@ export function readTsConfigFile(project: string): {
  * @throws {TsConfigFileNotFoundError}
  */
 export function readConfigFile(project: string): CMKConfig {
-  const { configFileName, config, compilerOptions, diagnostics } = readTsConfigFile(project);
+  const { configFileName, config, compilerOptions, wildcardDirectories, diagnostics } = readTsConfigFile(project);
   const basePath = dirname(configFileName);
   return {
     // If `include` is not specified, fallback to the default include spec。
@@ -262,6 +269,7 @@ export function readConfigFile(project: string): CMKConfig {
     basePath,
     configFileName,
     compilerOptions,
+    wildcardDirectories,
     diagnostics,
   };
 }

--- a/packages/core/src/test/faker.ts
+++ b/packages/core/src/test/faker.ts
@@ -4,7 +4,7 @@ import type { MatchesPattern, Resolver } from '../type.js';
 
 export function fakeConfig(args?: Partial<CMKConfig>): CMKConfig {
   return {
-    includes: [],
+    includes: ['/app/**/*'],
     excludes: [],
     dtsOutDir: 'generated',
     arbitraryExtensions: false,
@@ -14,6 +14,7 @@ export function fakeConfig(args?: Partial<CMKConfig>): CMKConfig {
     basePath: '/app',
     configFileName: '/app/tsconfig.json',
     compilerOptions: {},
+    wildcardDirectories: [{ fileName: '/app', recursive: true }],
     diagnostics: [],
     ...args,
   };


### PR DESCRIPTION
ref: #178 

This is a preparatory step for implementing watch mode. It enables the directories to be watched during watch mode to be referenced via `config.wildcardDirectories`.

This change is marked as a minor change, but this API is used only internally and has no impact on users.