### PR TITLE
Add `extendedSourceFiles` in `CMKConfig`

### DIFF
--- a/.changeset/khaki-pillows-change.md
+++ b/.changeset/khaki-pillows-change.md
@@ -1,0 +1,5 @@
+---
+'@css-modules-kit/core': minor
+---
+
+feat: add `extendedSourceFiles` in `CMKConfig`

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1,11 +1,9 @@
-import { realpathSync } from 'node:fs';
 import dedent from 'dedent';
 import ts from 'typescript';
 import { describe, expect, test } from 'vitest';
 import type { CMKConfig } from './config.js';
 import { readConfigFile } from './config.js';
 import { TsConfigFileNotFoundError } from './error.js';
-import { slash } from './path.js';
 import { createIFF } from './test/fixture.js';
 
 describe('readConfigFile', () => {
@@ -191,29 +189,6 @@ describe('readConfigFile', () => {
       `,
       });
       expect(readConfigFile(iff.rootDir).dtsOutDir).toBe(iff.join('generated2'));
-    });
-    test('inherits from a package', async () => {
-      const iff = await createIFF({
-        'node_modules/some-pkg/tsconfig.json': dedent`
-          {
-            "cmkOptions": { "dtsOutDir": "generated/cmk" }
-          }
-        `,
-        'tsconfig.json': dedent`
-          {
-            "extends": "some-pkg/tsconfig.json"
-          }
-        `,
-      });
-      expect(readConfigFile(iff.rootDir).dtsOutDir).toBe(iff.join('generated/cmk'));
-      expect(readConfigFile(iff.rootDir)).toStrictEqual(
-        expect.objectContaining({
-          dtsOutDir: iff.join('generated/cmk'),
-          // The path to tsconfig.json from the package is resolved using `realpath`.
-          // Therefore, the expected path is also resolved using `realpath`.
-          extendedSourceFiles: [slash(realpathSync(iff.join('node_modules/some-pkg/tsconfig.json')))],
-        }),
-      );
     });
     test('inherits from multiple files', async () => {
       const iff = await createIFF({

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -60,6 +60,8 @@ export interface CMKConfig {
   compilerOptions: ts.CompilerOptions;
   /** The directories to watch when watch mode is enabled. */
   wildcardDirectories: { fileName: string; recursive: boolean }[];
+  /** The tsconfig files inherited by `configFileName`. */
+  extendedSourceFiles: string[];
   /** The diagnostics that occurred while reading the config file. */
   diagnostics: Diagnostic[];
 }
@@ -259,6 +261,7 @@ export function readConfigFile(project: string): CMKConfig {
     configFileName,
     compilerOptions: parsedTsConfig.compilerOptions,
     wildcardDirectories: parsedTsConfig.wildcardDirectories,
+    extendedSourceFiles: parsedTsConfig.extendedSourceFiles ?? [],
     diagnostics: parsedTsConfig.diagnostics,
   };
 }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -246,7 +246,7 @@ export function readConfigFile(project: string): CMKConfig {
 
   const basePath = dirname(configFileName);
   return {
-    // If `include` is not specified, fallback to the default include spec。
+    // If `include` is not specified, fallback to the default include spec.
     // ref: https://github.com/microsoft/TypeScript/blob/caf1aee269d1660b4d2a8b555c2d602c97cb28d7/src/compiler/commandLineParser.ts#L3102
     includes: (parsedTsConfig.config.includes ?? [DEFAULT_INCLUDE_SPEC]).map((i) => join(basePath, i)),
     excludes: (parsedTsConfig.config.excludes ?? []).map((e) => join(basePath, e)),

--- a/packages/core/src/test/faker.ts
+++ b/packages/core/src/test/faker.ts
@@ -16,6 +16,7 @@ export function fakeConfig(args?: Partial<CMKConfig>): CMKConfig {
     compilerOptions: {},
     wildcardDirectories: [{ fileName: '/app', recursive: true }],
     diagnostics: [],
+    extendedSourceFiles: [],
     ...args,
   };
 }


### PR DESCRIPTION
ref: #178 

This is a preparatory step for implementing watch mode. This allows referencing the configuration files that should be watched in watch mode via `config.extendedSourceFiles`.

This change is marked as a minor change, but this API is used only internally and has no impact on users.