### PR TITLE
Bump extension API for enhanced Windows support

### DIFF
--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -8,4 +8,4 @@ license = "MIT"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.5.0"
+zed_extension_api = "0.7.0"


### PR DESCRIPTION
⚠️ Don't merge until Zed 0.205.x is on stable ⚠️

See https://github.com/zed-industries/zed/pull/37811

This PR bumps the zed extension API to the latest version, which makes std::env::current_dir() work correctly in WASI with Windows DOS paths.