### PR TITLE
Fix flaky test

### DIFF
--- a/.vscode-test.cjs
+++ b/.vscode-test.cjs
@@ -4,7 +4,7 @@ const baseConfig = /** @type {Parameters<typeof defineConfig>[0]} */ ({
   extensionDevelopmentPath: 'packages/vscode',
   version: process.env.VSCODE_VERSION ?? 'stable',
   mocha: {
-    timeout: 10000,
+    timeout: 30_000,
     require: ['tsx/cjs', './scripts/vscode-test-setup.ts'],
   },
   download: {

--- a/packages/vscode/vscode-test/util.ts
+++ b/packages/vscode/vscode-test/util.ts
@@ -10,7 +10,7 @@ export async function waitFor<T>(
   testFn: () => Promise<T>,
   options?: { timeout: number; interval: number },
 ): Promise<T> {
-  const timeout = options?.timeout ?? 5000;
+  const timeout = options?.timeout ?? 10_000;
   const interval = options?.interval ?? 50;
   const endTime = Date.now() + timeout;
 


### PR DESCRIPTION
The Windows runner is extremely slow and may exceed the current timeout duration.