### PR TITLE
Generate .d.ts files even if syntax or semantic errors are found

### DIFF
--- a/.changeset/busy-plants-take.md
+++ b/.changeset/busy-plants-take.md
@@ -1,0 +1,7 @@
+---
+'@css-modules-kit/ts-plugin': minor
+'@css-modules-kit/codegen': minor
+'@css-modules-kit/core': minor
+---
+
+feat: generate .d.ts files even if syntax or semantic errors are found

--- a/packages/codegen/src/runner.test.ts
+++ b/packages/codegen/src/runner.test.ts
@@ -204,6 +204,22 @@ describe('runCMK', () => {
         },
       ]
     `);
+    // Even if there is a syntax error, .d.ts files are generated.
+    expect(await iff.readFile('generated/src/a.module.css.d.ts')).toMatchInlineSnapshot(`
+      "// @ts-nocheck
+      declare const styles = {
+        a1: '' as readonly string,
+      };
+      export default styles;
+      "
+    `);
+    expect(await iff.readFile('generated/src/b.module.css.d.ts')).toMatchInlineSnapshot(`
+      "// @ts-nocheck
+      declare const styles = {
+      };
+      export default styles;
+      "
+    `);
   });
   test('reports semantic diagnostics in *.module.css', async () => {
     const iff = await createIFF({
@@ -246,6 +262,25 @@ describe('runCMK', () => {
           "text": "Cannot import module './c.module.css'",
         },
       ]
+    `);
+    // Even if there is a semantic error, .d.ts files are generated.
+    expect(await iff.readFile('generated/src/a.module.css.d.ts')).toMatchInlineSnapshot(`
+      "// @ts-nocheck
+      declare const styles = {
+        b_1: (await import('./b.module.css')).default.b_1,
+        b_2: (await import('./b.module.css')).default.b_2,
+      };
+      export default styles;
+      "
+    `);
+    expect(await iff.readFile('generated/src/b.module.css.d.ts')).toMatchInlineSnapshot(`
+      "// @ts-nocheck
+      declare const styles = {
+        b_1: '' as readonly string,
+        ...(await import('./c.module.css')).default,
+      };
+      export default styles;
+      "
     `);
   });
 });

--- a/packages/core/src/parser/css-module-parser.test.ts
+++ b/packages/core/src/parser/css-module-parser.test.ts
@@ -2,7 +2,7 @@ import dedent from 'dedent';
 import { describe, expect, test } from 'vitest';
 import { parseCSSModule, type ParseCSSModuleOptions } from './css-module-parser.js';
 
-const options: ParseCSSModuleOptions = { fileName: '/test.module.css', safe: false, keyframes: true };
+const options: ParseCSSModuleOptions = { fileName: '/test.module.css', includeSyntaxError: true, keyframes: true };
 
 describe('parseCSSModule', () => {
   test('collects local tokens', () => {
@@ -695,7 +695,35 @@ describe('parseCSSModule', () => {
       {
         "cssModule": {
           "fileName": "/test.module.css",
-          "localTokens": [],
+          "localTokens": [
+            {
+              "declarationLoc": {
+                "end": {
+                  "column": 6,
+                  "line": 1,
+                  "offset": 5,
+                },
+                "start": {
+                  "column": 1,
+                  "line": 1,
+                  "offset": 0,
+                },
+              },
+              "loc": {
+                "end": {
+                  "column": 3,
+                  "line": 1,
+                  "offset": 2,
+                },
+                "start": {
+                  "column": 2,
+                  "line": 1,
+                  "offset": 1,
+                },
+              },
+              "name": "a",
+            },
+          ],
           "text": ".a {",
           "tokenImporters": [],
         },
@@ -742,14 +770,15 @@ describe('parseCSSModule', () => {
       }
     `);
   });
-  test('parses CSS in a fault-tolerant manner if safe is true', () => {
-    const parsed = parseCSSModule(
-      dedent`
-        .a {
-      `,
-      { ...options, safe: true },
-    );
-    expect(parsed).toMatchInlineSnapshot(`
+  test('does not include syntax error in diagnostics if includeSyntaxError is false', () => {
+    expect(
+      parseCSSModule(
+        dedent`
+          .a {
+        `,
+        { ...options, includeSyntaxError: false },
+      ),
+    ).toMatchInlineSnapshot(`
       {
         "cssModule": {
           "fileName": "/test.module.css",

--- a/packages/ts-plugin/e2e-test/invalid-syntax.test.ts
+++ b/packages/ts-plugin/e2e-test/invalid-syntax.test.ts
@@ -44,9 +44,6 @@ describe('handle invalid syntax CSS without crashing', async () => {
     expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(normalizeDefinitions(expected));
   });
   test('does not report syntactic diagnostics', async () => {
-    // NOTE: The standard CSS Language Server reports invalid syntax errors.
-    // Therefore, if ts-plugin also reports it, the same error is reported twice.
-    // To avoid this, ts-plugin does not report invalid syntax errors.
     const res = await tsserver.sendSyntacticDiagnosticsSync({
       file: iff.paths['a.module.css'],
     });

--- a/packages/ts-plugin/src/language-plugin.ts
+++ b/packages/ts-plugin/src/language-plugin.ts
@@ -49,9 +49,10 @@ export function createCSSLanguagePlugin(
       const cssModuleCode = snapshot.getText(0, length);
       const { cssModule, diagnostics } = parseCSSModule(cssModuleCode, {
         fileName: scriptId,
-        // The CSS in the process of being written in an editor often contains invalid syntax.
-        // So, ts-plugin uses a fault-tolerant Parser to parse CSS.
-        safe: true,
+        // NOTE: The standard CSS Language Server reports invalid syntax errors.
+        // Therefore, if ts-plugin also reports it, the same error is reported twice.
+        // To avoid this, ts-plugin does not report invalid syntax errors.
+        includeSyntaxError: false,
         keyframes: config.keyframes,
       });
       // eslint-disable-next-line prefer-const


### PR DESCRIPTION
ref: #178 

The ts-plugin was generating type definitions for files containing errors, while codegen was not generating .d.ts files for files with errors. This created a discrepancy in the types recognized by both the tsserver and eslint Language Servers. While this issue is currently mostly unnoticed by most users, it will become more apparent once watch mode is implemented.

Therefore, we'll modify codegen to generate .d.ts files for files containing errors as well.

Incidentally, `tsc` exhibits similar behavior.
