### PR TITLE
Run test on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20, 22]
-        os: [ubuntu-24.04-arm, windows-11-arm]
+        os: [ubuntu-24.04-arm, macos-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20, 22]
-        os: [ubuntu-24.04-arm, windows-11-arm]
+        os: [ubuntu-24.04-arm, macos-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
ref: #178 

File system watching behavior varies slightly across operating systems. Therefore, before implementing watch mode, we will configure CI to run tests on macOS as well.