### PR TITLE
Remove `Cannot import module 'xxx'` error

### DIFF
--- a/.changeset/icy-turkeys-joke.md
+++ b/.changeset/icy-turkeys-joke.md
@@ -1,0 +1,5 @@
+---
+'@css-modules-kit/core': minor
+---
+
+feat!: remove `Cannot import module 'xxx'` error

--- a/packages/core/src/checker.test.ts
+++ b/packages/core/src/checker.test.ts
@@ -285,59 +285,6 @@ describe('checkCSSModule', () => {
       ]
     `);
   });
-  test('report diagnostics for non-existing module', () => {
-    const args = prepareCheckerArgs([
-      fakeCSSModule({
-        fileName: '/a.module.css',
-        tokenImporters: [
-          fakeAtImportTokenImporter({ from: './b.module.css', fromLoc: fakeLoc({ column: 1 }) }),
-          fakeAtValueTokenImporter({
-            from: './c.module.css',
-            fromLoc: fakeLoc({ column: 2 }),
-            values: [fakeAtValueTokenImporterValue({ name: 'c_1', loc: fakeLoc({ column: 3 }) })],
-          }),
-        ],
-      }),
-    ]);
-    const diagnostics = checkCSSModule(
-      args.cssModules[0],
-      args.config,
-      args.exportBuilder,
-      args.matchesPattern,
-      args.resolver,
-      args.getCSSModule,
-    );
-    expect(diagnostics).toMatchInlineSnapshot(`
-      [
-        {
-          "category": "error",
-          "file": {
-            "fileName": "/a.module.css",
-            "text": "",
-          },
-          "length": 0,
-          "start": {
-            "column": 1,
-            "line": 1,
-          },
-          "text": "Cannot import module './b.module.css'",
-        },
-        {
-          "category": "error",
-          "file": {
-            "fileName": "/a.module.css",
-            "text": "",
-          },
-          "length": 0,
-          "start": {
-            "column": 2,
-            "line": 1,
-          },
-          "text": "Cannot import module './c.module.css'",
-        },
-      ]
-    `);
-  });
   test('report diagnostics for non-exported token', () => {
     const args = prepareCheckerArgs([
       fakeCSSModule({

--- a/packages/core/src/checker.ts
+++ b/packages/core/src/checker.ts
@@ -8,7 +8,6 @@ import type {
   Location,
   MatchesPattern,
   Resolver,
-  TokenImporter,
 } from './type.js';
 import { isValidAsJSIdentifier } from './util.js';
 
@@ -40,10 +39,7 @@ export function checkCSSModule(
     const from = resolver(tokenImporter.from, { request: cssModule.fileName });
     if (!from || !matchesPattern(from)) continue;
     const imported = getCSSModule(from);
-    if (!imported) {
-      diagnostics.push(createCannotImportModuleDiagnostic(cssModule, tokenImporter));
-      continue;
-    }
+    if (!imported) continue;
 
     if (tokenImporter.type === 'value') {
       const exportRecord = exportBuilder.build(imported);
@@ -75,16 +71,6 @@ export function checkCSSModule(
     }
   }
   return diagnostics;
-}
-
-function createCannotImportModuleDiagnostic(cssModule: CSSModule, tokenImporter: TokenImporter): Diagnostic {
-  return {
-    text: `Cannot import module '${tokenImporter.from}'`,
-    category: 'error',
-    file: { fileName: cssModule.fileName, text: cssModule.text },
-    start: { line: tokenImporter.fromLoc.start.line, column: tokenImporter.fromLoc.start.column },
-    length: tokenImporter.fromLoc.end.offset - tokenImporter.fromLoc.start.offset,
-  };
 }
 
 function createModuleHasNoExportedTokenDiagnostic(

--- a/packages/ts-plugin/e2e-test/feature/semantic-diagnostics.test.ts
+++ b/packages/ts-plugin/e2e-test/feature/semantic-diagnostics.test.ts
@@ -79,20 +79,6 @@ test('Semantic Diagnostics', async () => {
         },
         "text": "Module './c.module.css' has no exported token 'c_3'.",
       },
-      {
-        "category": "error",
-        "code": 0,
-        "end": {
-          "line": 5,
-          "offset": 24,
-        },
-        "source": "css-modules-kit",
-        "start": {
-          "line": 5,
-          "offset": 10,
-        },
-        "text": "Cannot import module './d.module.css'",
-      },
     ]
   `);
 });


### PR DESCRIPTION
## Background

Currently, css-modules-kit reports an error `Cannot import module 'xxx'` when code tries to import a non-existent CSS Module file. This helps users catch mistakes early.

However, in certain cases, this error is not reported. Specifically, when importing a non-existent CSS Module file using an import alias.

`src/a.module.css`:
```css
@import '@/src/non-existent.module.css';
@import './non-existent.module.css';
```

`tsconfig.json`:
```json
{
  "compilerOptions": {
    "paths": { "@/*": ["./*"] }
  },
  "cmkOptions": {
    "enabled": true
  }
}
```

<img width="1016" height="419" alt="image" src="https://github.com/user-attachments/assets/270618d8-67d0-404d-b587-c2615b3858cb" />

This happens because import specifiers are resolved differently for `@/src/non-existent.module.css` and `./non-existent.module.css`. The former uses `ts.resolveModuleName`, while the latter uses `resolve(fileURLToPath(new URL(specifier, pathToFileURL(options.request)).href))`. The latter can resolve the specifier even if the file does not exist, while the former cannot resolve non-existent files.

Moreover, css-modules-kit does not report the error for specifiers that cannot be resolved. Ideally, it should report an error in such cases. However, users often write code like `@import 'https://example.com/remote.css';` to import CSS files that are resolved at runtime. To avoid reporting errors for these cases, css-modules-kit is designed not to report errors for specifiers that cannot be resolved.

This behavior of not reporting errors for unresolved specifiers also applies when using import aliases. As a result, import specifiers like `@/src/non-existent.module.css` do not trigger errors even when they cannot be resolved.

## Solution

The `Cannot import module 'xxx'` error is useful for users, but it conflicts with the behavior of not reporting errors for unresolved specifiers. Additionally, this error is typically detected by the bundler. Even if css-modules-kit does not report it, users will likely notice the mistakes. Therefore, we will remove the `Cannot import module 'xxx'` error entirely.

With this change, it will also be possible to unify the import specifier resolution method to `ts.resolveModuleName` in the future.

