### PR TITLE
Prevent URL specifiers from being resolved by import aliases

### DIFF
--- a/.changeset/cyan-pans-invite.md
+++ b/.changeset/cyan-pans-invite.md
@@ -1,0 +1,5 @@
+---
+'@css-modules-kit/core': patch
+---
+
+fix: prevent URL specifiers from being resolved by import aliases

--- a/packages/core/src/resolver.test.ts
+++ b/packages/core/src/resolver.test.ts
@@ -117,8 +117,7 @@ describe('createResolver', async () => {
     );
     expect(resolve('https://example.com/a.module.css', { request })).toBe(undefined);
     // Tests that the URL specifier is not resolved using import aliases such as paths.
-    // FIXME: It should return `undefined`.
-    expect(resolve('https://paths.com/a.module.css', { request })).toBe(iff.paths['paths1/a.module.css']);
+    expect(resolve('https://paths.com/a.module.css', { request })).toBe(undefined);
     expect(resolve('unknown://example.com/a.module.css', { request })).toBe(undefined);
     expect(resolve(`data:,${encodeURIComponent('.a_1 { color: red; }')}`, { request })).toBe(undefined);
   });

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -1,13 +1,14 @@
 import type { CompilerOptions } from 'typescript';
 import ts from 'typescript';
-import { resolve } from './path.js';
 import type { Resolver, ResolverOptions } from './type.js';
+import { isURLSpecifier } from './util.js';
 
 export function createResolver(
   compilerOptions: CompilerOptions,
   moduleResolutionCache: ts.ModuleResolutionCache | undefined,
 ): Resolver {
   return (specifier: string, options: ResolverOptions) => {
+    if (isURLSpecifier(specifier)) return undefined;
     const host: ts.ModuleResolutionHost = {
       ...ts.sys,
       fileExists: (fileName) => {
@@ -26,7 +27,7 @@ export function createResolver(
     );
     if (resolvedModule) {
       // TODO: Logging that the paths is used.
-      return resolve(resolvedModule.resolvedFileName.replace(/\.module\.d\.css\.ts$/u, '.module.css'));
+      return resolvedModule.resolvedFileName.replace(/\.module\.d\.css\.ts$/u, '.module.css');
     }
     return undefined;
   };


### PR DESCRIPTION
It mimics the behavior of tools like vite.