### PR TITLE
chore(examples): update target from ES5 to ES2015 in example tsconfigs

### DIFF
--- a/examples/1-basic/tsconfig.json
+++ b/examples/1-basic/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES5", // Simplify tsserver.log
-    "lib": ["ES5"], // Simplify tsserver.log
+    "target": "es2015",
+    "lib": ["ES2015"],
     "module": "Preserve",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",

--- a/examples/5-normal-css/tsconfig.json
+++ b/examples/5-normal-css/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES5", // Simplify tsserver.log
-    "lib": ["ES5"], // Simplify tsserver.log
+    "target": "ES2015",
+    "lib": ["ES2015"],
     "module": "Preserve",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",

--- a/examples/6-project-external-file/tsconfig.json
+++ b/examples/6-project-external-file/tsconfig.json
@@ -2,8 +2,8 @@
   "exclude": ["src/external.module.css"],
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES5", // Simplify tsserver.log
-    "lib": ["ES5"], // Simplify tsserver.log
+    "target": "ES2015",
+    "lib": ["ES2015"],
     "module": "Preserve",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

- `target: ES5` is deprecated in TypeScript v6
- Update `target` and `lib` from `ES5` to `ES2015` in example `tsconfig.json` files
- Remove the `// Simplify tsserver.log` comments that were tied to the old ES5 setting


🤖 Generated with [Claude Code](https://claude.com/claude-code)