### PR TITLE
chore: add `enableGlobalVirtualStore: true`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@latest
   vite-plus: latest
   vitest: npm:@voidzero-dev/vite-plus-test@latest
+enableGlobalVirtualStore: true
 minimumReleaseAge: 4320
 overrides:
   vite: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,11 +6,11 @@ allowBuilds:
   esbuild: true
   keytar: false
 blockExoticSubdeps: true
-minimumReleaseAge: 4320
 catalog:
   vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
   vite-plus: latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+minimumReleaseAge: 4320
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'


### PR DESCRIPTION
- https://pnpm.io/settings#enableglobalvirtualstore
- https://pnpm.io/11.x/global-virtual-store
- https://pnpm.io/11.x/git-worktrees

When `enableGlobalVirtualStore: false`, the following `node_modules` directory is created.

```console
$ l -la node_modules/
total 104
drwxr-xr-x@  23 mizdra  staff    736 Apr 19 18:26 .
drwxr-xr-x@  34 mizdra  staff   1088 Apr 19 18:26 ..
drwxr-xr-x@  18 mizdra  staff    576 Apr 19 18:26 .bin
-rw-r--r--@   1 mizdra  staff  46455 Apr 19 18:26 .modules.yaml
drwxr-xr-x@ 661 mizdra  staff  21152 Apr 19 18:26 .pnpm
-rw-r--r--@   1 mizdra  staff   2221 Apr 19 18:26 .pnpm-workspace-state-v1.json
drwxr-xr-x@   5 mizdra  staff    160 Apr 19 18:26 @changesets
drwxr-xr-x@   3 mizdra  staff     96 Apr 19 18:26 @css-modules-kit
drwxr-xr-x@   3 mizdra  staff     96 Apr 19 18:26 @eslint
drwxr-xr-x@   5 mizdra  staff    160 Apr 19 18:26 @mizdra
drwxr-xr-x@   7 mizdra  staff    224 Apr 19 18:26 @types
drwxr-xr-x@   3 mizdra  staff     96 Apr 19 18:26 @typescript
drwxr-xr-x@   5 mizdra  staff    160 Apr 19 18:26 @vscode
lrwxr-xr-x@   1 mizdra  staff     38 Apr 19 18:26 dedent -> .pnpm/dedent@1.7.2/node_modules/dedent
lrwxr-xr-x@   1 mizdra  staff     39 Apr 19 18:26 eslint -> .pnpm/eslint@10.2.0/node_modules/eslint
lrwxr-xr-x@   1 mizdra  staff     37 Apr 19 18:26 mocha -> .pnpm/mocha@11.7.5/node_modules/mocha
lrwxr-xr-x@   1 mizdra  staff     36 Apr 19 18:26 ovsx -> .pnpm/ovsx@0.10.10/node_modules/ovsx
lrwxr-xr-x@   1 mizdra  staff     48 Apr 19 18:26 rolldown -> .pnpm/rolldown@1.0.0-rc.13/node_modules/rolldown
lrwxr-xr-x@   1 mizdra  staff     62 Apr 19 18:26 stylelint -> .pnpm/stylelint@17.6.0_typescript@6.0.2/node_modules/stylelint
lrwxr-xr-x@   1 mizdra  staff     33 Apr 19 18:26 tsx -> .pnpm/tsx@4.21.0/node_modules/tsx
lrwxr-xr-x@   1 mizdra  staff     46 Apr 19 18:26 typescript -> .pnpm/typescript@6.0.2/node_modules/typescript
lrwxr-xr-x@   1 mizdra  staff    149 Apr 19 18:26 vite-plus -> .pnpm/vite-plus@0.1.16_@types+node@25.5.2_esbuild@0.27.7_tsx@4.21.0_typescript@6.0.2_vite@8.0_c67d6d1b7aaf2740d94353878b80c34f/node_modules/vite-plus
lrwxr-xr-x@   1 mizdra  staff    168 Apr 19 18:26 vitest -> .pnpm/@voidzero-dev+vite-plus-test@0.1.16_@types+node@25.5.2_esbuild@0.27.7_tsx@4.21.0_typesc_d9d6de7afd15cc08c9d54a997cfe644c/node_modules/@voidzero-dev/vite-plus-test
```

On the other hand, when `enableGlobalVirtualStore: true`, the following `node_modules` directory is created.

```console
$ ls -la node_modules/
total 104
drwxr-xr-x@ 23 mizdra  staff    736 Apr 19 18:20 .
drwxr-xr-x@ 34 mizdra  staff   1088 Apr 19 18:20 ..
drwxr-xr-x@ 18 mizdra  staff    576 Apr 19 18:20 .bin
-rw-r--r--@  1 mizdra  staff  46497 Apr 19 18:20 .modules.yaml
drwxr-xr-x@  4 mizdra  staff    128 Apr 19 18:20 .pnpm
-rw-r--r--@  1 mizdra  staff   2221 Apr 19 18:20 .pnpm-workspace-state-v1.json
drwxr-xr-x@  5 mizdra  staff    160 Apr 19 18:20 @changesets
drwxr-xr-x@  3 mizdra  staff     96 Apr 19 18:20 @css-modules-kit
drwxr-xr-x@  3 mizdra  staff     96 Apr 19 18:20 @eslint
drwxr-xr-x@  5 mizdra  staff    160 Apr 19 18:20 @mizdra
drwxr-xr-x@  7 mizdra  staff    224 Apr 19 18:20 @types
drwxr-xr-x@  3 mizdra  staff     96 Apr 19 18:20 @typescript
drwxr-xr-x@  5 mizdra  staff    160 Apr 19 18:20 @vscode
lrwxr-xr-x@  1 mizdra  staff    148 Apr 19 18:20 dedent -> ../../../../../.local/share/pnpm/store/v10/links/@/dedent/1.7.2/f1d8ffc79ddbbcb206377acaf37acc132187e6b7e325cea63ee6c21e6a26bfee/node_modules/dedent
lrwxr-xr-x@  1 mizdra  staff    149 Apr 19 18:20 eslint -> ../../../../../.local/share/pnpm/store/v10/links/@/eslint/10.2.0/b74bb1689583219d316a08fb3c8003122b045058abab8b7c724209cb1a395a1e/node_modules/eslint
lrwxr-xr-x@  1 mizdra  staff    147 Apr 19 18:20 mocha -> ../../../../../.local/share/pnpm/store/v10/links/@/mocha/11.7.5/6244402cceb75a4bd84212439f11300c07415d1e4fc701dce594c603145fff22/node_modules/mocha
lrwxr-xr-x@  1 mizdra  staff    146 Apr 19 18:20 ovsx -> ../../../../../.local/share/pnpm/store/v10/links/@/ovsx/0.10.10/f0009d975562d3822a2f98a5f1849c47b715d60323bf6c352aad7b7acba2e401/node_modules/ovsx
lrwxr-xr-x@  1 mizdra  staff    158 Apr 19 18:20 rolldown -> ../../../../../.local/share/pnpm/store/v10/links/@/rolldown/1.0.0-rc.13/807b821803762f9a40173f5ac4eddeee235afa8f91792fb01dd7b98e967e15d4/node_modules/rolldown
lrwxr-xr-x@  1 mizdra  staff    155 Apr 19 18:20 stylelint -> ../../../../../.local/share/pnpm/store/v10/links/@/stylelint/17.6.0/da0d6b24539728da1121c378879fd1b8d0a5d3d4edb42dc52dd47e33edc52a35/node_modules/stylelint
lrwxr-xr-x@  1 mizdra  staff    143 Apr 19 18:20 tsx -> ../../../../../.local/share/pnpm/store/v10/links/@/tsx/4.21.0/c7f80903aa28b21284b0fce1fd41d585d342287b136bebcfe3176b71b8d71b8a/node_modules/tsx
lrwxr-xr-x@  1 mizdra  staff    156 Apr 19 18:20 typescript -> ../../../../../.local/share/pnpm/store/v10/links/@/typescript/6.0.2/89ed7dc8c9e8b4c27fd7510b35f9f9f2656b24fc0b97ee63c0fab7b7a65905b9/node_modules/typescript
lrwxr-xr-x@  1 mizdra  staff    155 Apr 19 18:20 vite-plus -> ../../../../../.local/share/pnpm/store/v10/links/@/vite-plus/0.1.16/93d06ee8b234d1080f65944ba85d5bfee5046c553dd49d4e181d0d34351a0c48/node_modules/vite-plus
lrwxr-xr-x@  1 mizdra  staff    191 Apr 19 18:20 vitest -> ../../../../../.local/share/pnpm/store/v10/links/@voidzero-dev/vite-plus-test/0.1.16/f6915396929a38146096f539c64cab94c2086ef7770b98b10f83bff43d24bdc1/node_modules/@voidzero-dev/vite-plus-test
```

## Benchmark

`enableGlobalVirtualStore: true` seems to be slow. Could this be because there are few packages?

```console
$ pnpm -v
10.33.0
$ envinfo --system --binaries

  System:
    OS: macOS 26.4.1
    CPU: (14) arm64 Apple M4 Pro
    Memory: 1.28 GB / 48.00 GB
    Shell: 5.9 - /bin/zsh
  Binaries:
    Node: 24.15.0 - /Users/mizdra/.vite-plus/js_runtime/node/24.15.0/bin/node
    npm: 11.12.1 - /Users/mizdra/.vite-plus/js_runtime/node/24.15.0/bin/npm
    pnpm: 10.33.0 - /Users/mizdra/.local/share/mise/installs/pnpm/10.33.0/pnpm
    bun: 1.3.6 - /Users/mizdra/.local/share/mise/installs/bun/1.3.6/bin/bun

$ hyperfine \
  --warmup 1 \
  --prepare="rm -rf node_modules packages/*/node_modules" \
  "pnpm --config.enableGlobalVirtualStore=false --offline i" \
  --prepare="rm -rf node_modules packages/*/node_modules" \
  "pnpm --config.enableGlobalVirtualStore=true  --offline i"
Benchmark 1: pnpm --config.enableGlobalVirtualStore=false --offline i
  Time (mean ± σ):      1.733 s ±  0.059 s    [User: 1.648 s, System: 4.114 s]
  Range (min … max):    1.672 s …  1.835 s    10 runs

Benchmark 2: pnpm --config.enableGlobalVirtualStore=true  --offline i
  Time (mean ± σ):      2.724 s ±  0.109 s    [User: 2.381 s, System: 6.990 s]
  Range (min … max):    2.621 s …  2.962 s    10 runs

Summary
  pnpm --config.enableGlobalVirtualStore=false --offline i ran
    1.57 ± 0.08 times faster than pnpm --config.enableGlobalVirtualStore=true  --offline i
```
