### PR TITLE
Revert "chore: add `enableGlobalVirtualStore: true`"

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,12 +6,11 @@ allowBuilds:
   esbuild: true
   keytar: false
 blockExoticSubdeps: true
+minimumReleaseAge: 4320
 catalog:
   vite: npm:@voidzero-dev/vite-plus-core@latest
-  vite-plus: latest
   vitest: npm:@voidzero-dev/vite-plus-test@latest
-enableGlobalVirtualStore: true
-minimumReleaseAge: 4320
+  vite-plus: latest
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'


### PR DESCRIPTION
Reverts mizdra/css-modules-kit#365

I encountered https://github.com/pnpm/pnpm/issues/9739, so I am reverting this change.