### PR TITLE
feat(core): Support ${configDir}

### DIFF
--- a/.changeset/cute-files-pump.md
+++ b/.changeset/cute-files-pump.md
@@ -1,0 +1,5 @@
+---
+'@css-modules-kit/core': minor
+---
+
+Support ${configDir}

--- a/.changeset/cute-files-pump.md
+++ b/.changeset/cute-files-pump.md
@@ -2,4 +2,4 @@
 '@css-modules-kit/core': minor
 ---
 
-Support ${configDir}
+feat(core): support `${configDir}` in tsconfig options

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -268,6 +268,29 @@ describe('readConfigFile', () => {
         }),
       );
     });
+    // FIXME
+    test.fails('resolves relative paths against the defining tsconfig directory', async () => {
+      const iff = await createIFF({
+        'tsconfig.base.json': dedent`
+          {
+            "include": ["src"],
+            "exclude": ["dist"],
+            "cmkOptions": {
+              "dtsOutDir": "generated"
+            }
+          }
+        `,
+        'app/tsconfig.json': dedent`
+          {
+            "extends": "../tsconfig.base.json"
+          }
+        `,
+      });
+      const result = readConfigFile(iff.join('app'));
+      expect(result.includes).toEqual([iff.join('src')]);
+      expect(result.excludes).toEqual([iff.join('dist')]);
+      expect(result.dtsOutDir).toBe(iff.join('generated'));
+    });
   });
   describe('diagnostics', () => {
     test('returns diagnostics and a config object with error values excluded if config file has semantic errors', async () => {

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -389,13 +389,17 @@ describe('readConfigFile', () => {
         'tsconfig.a.json': dedent`
           {
             "include": ["./types", "\${configDir}/src"],
-            "exclude": ["./dist", "\${configDir}/dist"]
+            "exclude": ["./dist", "\${configDir}/dist"],
+            "cmkOptions": {
+              "dtsOutDir": "\${configDir}/generated"
+            }
           }
         `,
       });
       const result = readConfigFile(iff.join('apps/app'));
       expect(result.includes).toEqual([iff.join('types'), iff.join('apps/app/src')]);
       expect(result.excludes).toEqual([iff.join('dist'), iff.join('apps/app/dist')]);
+      expect(result.dtsOutDir).toBe(iff.join('apps/app/generated'));
     });
   });
 });

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -379,27 +379,28 @@ describe('readConfigFile', () => {
     });
   });
   describe('configDir template variable', () => {
-    test('correctly resolves configDir', async () => {
+    // oxlint-disable-next-line no-template-curly-in-string
+    test('resolve ${configDir} with the entry tsconfig directory', async () => {
       const iff = await createIFF({
-        'apps/app/tsconfig.json': dedent`
+        'tsconfig.base.json': dedent`
           {
-            "extends": ["../../tsconfig.a.json"]
-          }
-        `,
-        'tsconfig.a.json': dedent`
-          {
-            "include": ["./types", "\${configDir}/src"],
-            "exclude": ["./dist", "\${configDir}/dist"],
+            "include": ["\${configDir}/src"],
+            "exclude": ["\${configDir}/dist"],
             "cmkOptions": {
               "dtsOutDir": "\${configDir}/generated"
             }
           }
         `,
+        'app/tsconfig.json': dedent`
+          {
+            "extends": "../tsconfig.base.json",
+          }
+        `,
       });
-      const result = readConfigFile(iff.join('apps/app'));
-      expect(result.includes).toEqual([iff.join('types'), iff.join('apps/app/src')]);
-      expect(result.excludes).toEqual([iff.join('dist'), iff.join('apps/app/dist')]);
-      expect(result.dtsOutDir).toBe(iff.join('apps/app/generated'));
+      const result = readConfigFile(iff.join('app'));
+      expect(result.includes).toEqual([iff.join('app/src')]);
+      expect(result.excludes).toEqual([iff.join('app/dist')]);
+      expect(result.dtsOutDir).toBe(iff.join('app/generated'));
     });
   });
 });

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -378,4 +378,24 @@ describe('readConfigFile', () => {
       ]);
     });
   });
+  describe('configDir template variable', () => {
+    test('correctly resolves configDir', async () => {
+      const iff = await createIFF({
+        'apps/app/tsconfig.json': dedent`
+          {
+            "extends": ["../../tsconfig.a.json"]
+          }
+        `,
+        'tsconfig.a.json': dedent`
+          {
+            "include": ["./types", "\${configDir}/src"],
+            "exclude": ["./dist", "\${configDir}/dist"]
+          }
+        `,
+      });
+      const result = readConfigFile(iff.join('apps/app'));
+      expect(result.includes).toEqual([iff.join('types'), iff.join('apps/app/src')]);
+      expect(result.excludes).toEqual([iff.join('dist'), iff.join('apps/app/dist')]);
+    });
+  });
 });

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -402,5 +402,30 @@ describe('readConfigFile', () => {
       expect(result.excludes).toEqual([iff.join('app/dist')]);
       expect(result.dtsOutDir).toBe(iff.join('app/generated'));
     });
+    // oxlint-disable-next-line no-template-curly-in-string
+    test('does not replace ${configDir} if it is not at the start of the path', async () => {
+      const iff = await createIFF({
+        'tsconfig.json': dedent`
+          {
+            "include": ["./\${configDir}/src"]
+          }
+        `,
+      });
+      const result = readConfigFile(iff.rootDir);
+      // oxlint-disable-next-line no-template-curly-in-string
+      expect(result.includes).toEqual([iff.join('${configDir}/src')]);
+    });
+    // oxlint-disable-next-line no-template-curly-in-string
+    test('replaces ${configDir} case-insensitively', async () => {
+      const iff = await createIFF({
+        'tsconfig.json': dedent`
+          {
+            "include": ["\${CONFIGDIR}/src"]
+          }
+        `,
+      });
+      const result = readConfigFile(iff.rootDir);
+      expect(result.includes).toEqual([iff.join('src')]);
+    });
   });
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -229,6 +229,11 @@ function parseTsConfigFile(fileName: string) {
   };
 }
 
+// https://github.com/microsoft/TypeScript/blob/55423abe4d029017f19b6e4c32097591994836b4/src/compiler/commandLineParser.ts#L3299-L3328
+function getSubstitutedPath(path: string, basePath: string) {
+  return join(basePath, path.replace(/^\$\{configDir}/i, './'));
+}
+
 /**
  * Reads the `tsconfig.json` file and returns the normalized config.
  * Even if the `tsconfig.json` file contains syntax or semantic errors,
@@ -257,16 +262,13 @@ export function readConfigFile(project: string): CMKConfig {
 
   const basePath = dirname(configFileName);
 
-  // https://github.com/microsoft/TypeScript/blob/55423abe4d029017f19b6e4c32097591994836b4/src/compiler/commandLineParser.ts#L3299-L3328
-  function resolvePath(path: string) {
-    return join(basePath, path.replace(/^\$\{configDir}/i, './'));
-  }
-
   return {
     // If `include` is not specified, fallback to the default include spec。
     // ref: https://github.com/microsoft/TypeScript/blob/caf1aee269d1660b4d2a8b555c2d602c97cb28d7/src/compiler/commandLineParser.ts#L3102
-    includes: (parsedTsConfig.config.includes ?? [DEFAULT_INCLUDE_SPEC]).map(resolvePath),
-    excludes: (parsedTsConfig.config.excludes ?? []).map(resolvePath),
+    includes: (parsedTsConfig.config.includes ?? [DEFAULT_INCLUDE_SPEC]).map((path) =>
+      getSubstitutedPath(path, basePath),
+    ),
+    excludes: (parsedTsConfig.config.excludes ?? []).map((path) => getSubstitutedPath(path, basePath)),
     dtsOutDir: join(basePath, parsedTsConfig.config.dtsOutDir ?? 'generated'),
     arbitraryExtensions: parsedTsConfig.config.arbitraryExtensions ?? false,
     namedExports: parsedTsConfig.config.namedExports ?? false,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -269,7 +269,7 @@ export function readConfigFile(project: string): CMKConfig {
       getSubstitutedPath(path, basePath),
     ),
     excludes: (parsedTsConfig.config.excludes ?? []).map((path) => getSubstitutedPath(path, basePath)),
-    dtsOutDir: join(basePath, parsedTsConfig.config.dtsOutDir ?? 'generated'),
+    dtsOutDir: getSubstitutedPath(parsedTsConfig.config.dtsOutDir ?? 'generated', basePath),
     arbitraryExtensions: parsedTsConfig.config.arbitraryExtensions ?? false,
     namedExports: parsedTsConfig.config.namedExports ?? false,
     prioritizeNamedImports: parsedTsConfig.config.prioritizeNamedImports ?? false,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -256,11 +256,17 @@ export function readConfigFile(project: string): CMKConfig {
   }
 
   const basePath = dirname(configFileName);
+
+  // https://github.com/microsoft/TypeScript/blob/55423abe4d029017f19b6e4c32097591994836b4/src/compiler/commandLineParser.ts#L3299-L3328
+  function resolvePath(path: string) {
+    return join(basePath, path.replace(/^\$\{configDir}/i, './'));
+  }
+
   return {
     // If `include` is not specified, fallback to the default include spec。
     // ref: https://github.com/microsoft/TypeScript/blob/caf1aee269d1660b4d2a8b555c2d602c97cb28d7/src/compiler/commandLineParser.ts#L3102
-    includes: (parsedTsConfig.config.includes ?? [DEFAULT_INCLUDE_SPEC]).map((i) => join(basePath, i)),
-    excludes: (parsedTsConfig.config.excludes ?? []).map((e) => join(basePath, e)),
+    includes: (parsedTsConfig.config.includes ?? [DEFAULT_INCLUDE_SPEC]).map(resolvePath),
+    excludes: (parsedTsConfig.config.excludes ?? []).map(resolvePath),
     dtsOutDir: join(basePath, parsedTsConfig.config.dtsOutDir ?? 'generated'),
     arbitraryExtensions: parsedTsConfig.config.arbitraryExtensions ?? false,
     namedExports: parsedTsConfig.config.namedExports ?? false,


### PR DESCRIPTION
Resolves #368.

Included and excluded paths using `${configDir}` are now resolved correctly. The variable, recognized only if placed at the very start, is case-insensitively replaced with `./`; the path is then joined with the base directory's path as usual.