### PR TITLE
refactor(ts-plugin): split go-to-definition e2e tests into per-behavior cases

### DIFF
--- a/packages/ts-plugin/e2e-test/feature/go-to-definition.test.ts
+++ b/packages/ts-plugin/e2e-test/feature/go-to-definition.test.ts
@@ -1,317 +1,406 @@
 import dedent from 'dedent';
 import { describe, expect, test } from 'vite-plus/test';
-import { createIFF } from '../test-util/fixture.js';
+import { buildStylesImport, buildTSConfigJSON } from '../../test/builder.js';
+import { setupFixture } from '../test-util/fixture.js';
 import { formatPath, launchTsserver, normalizeDefinitions } from '../test-util/tsserver.js';
 
-describe.each([
-  {
-    namedExports: false,
-    importStatement: "import styles from './a.module.css';",
-    stylesOffset: 8,
-    specifierOffset: 20,
-  },
-  {
-    namedExports: true,
-    importStatement: "import * as styles from './a.module.css';",
-    stylesOffset: 13,
-    specifierOffset: 25,
-  },
-])(
-  'Go to Definition (namedExports: $namedExports)',
-  async ({ importStatement, namedExports, stylesOffset, specifierOffset }) => {
-    const tsserver = launchTsserver();
-    const iff = await createIFF({
-      'index.ts': dedent`
-        ${importStatement}
-        styles.a_1;
-        styles.a_2;
-        styles.a_3;
-        styles['a-4'];
-        styles.b_1;
-        styles.c_1;
-        styles.c_alias;
-      `,
-      'a.module.css': dedent`
-        @import './b.module.css';
-        @value c_1, c_2 as c_alias from './c.module.css';
-        .a_1 { color: red; }
-        .a_2 { color: red; }
-        .a_2 { color: red; }
-        @value a_3: red;
-        .a-4 { color: red; }
-        @import url(./b.module.css);
-      `,
-      'b.module.css': dedent`
-        .b_1 { color: red; }
-      `,
-      'c.module.css': dedent`
-        @value c_1: red;
-        @value c_2: red;
-      `,
-      'tsconfig.json': dedent`
-        {
-          "compilerOptions": {
-            "paths": { "@/*": ["./*"] }
+const tsserver = launchTsserver();
+
+describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: $namedExports', ({ namedExports }) => {
+  describe('jumps to the top of a CSS module file', () => {
+    test('from the styles binding in the import statement', async () => {
+      const { iff, getLoc } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': buildStylesImport('./a.module.css', { namedExports }),
+        'a.module.css': '',
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['index.ts'],
+        ...getLoc('index.ts', 'styles'),
+      });
+
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['a.module.css']),
+            start: { line: 1, offset: 1 },
+            end: { line: 1, offset: 1 },
           },
-          "cmkOptions": {
-            "enabled": true,
-            "dtsOutDir": "generated",
-            "namedExports": ${namedExports}
-          }
-        }
-      `,
+        ]),
+      );
     });
-    await tsserver.sendUpdateOpen({
-      openFiles: [{ file: iff.paths['index.ts'] }],
+
+    test('from the import specifier string', async () => {
+      const { iff, getLoc } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': buildStylesImport('./a.module.css', { namedExports }),
+        'a.module.css': '',
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['index.ts'],
+        ...getLoc('index.ts', "'./a.module.css'"),
+      });
+
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['a.module.css']),
+            start: { line: 1, offset: 1 },
+            end: { line: 1, offset: 1 },
+          },
+        ]),
+      );
     });
-    test.each([
-      {
-        name: 'styles in index.ts',
-        file: iff.paths['index.ts'],
-        line: 1,
-        offset: stylesOffset,
-        expected: [
-          { file: formatPath(iff.paths['a.module.css']), start: { line: 1, offset: 1 }, end: { line: 1, offset: 1 } },
-        ],
-      },
-      {
-        name: "'./a.module.css' in index.ts",
-        file: iff.paths['index.ts'],
-        line: 1,
-        offset: specifierOffset,
-        expected: [
-          { file: formatPath(iff.paths['a.module.css']), start: { line: 1, offset: 1 }, end: { line: 1, offset: 1 } },
-        ],
-      },
-      {
-        name: "'./b.module.css' in a.module.css",
+
+    test('from the @import specifier string', async () => {
+      const { iff, getLoc } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': buildStylesImport('./a.module.css', { namedExports }),
+        'a.module.css': `@import './b.module.css';`,
+        'b.module.css': '',
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
         file: iff.paths['a.module.css'],
-        line: 1,
-        offset: 9,
-        expected: [
-          { file: formatPath(iff.paths['b.module.css']), start: { line: 1, offset: 1 }, end: { line: 1, offset: 1 } },
-        ],
-      },
-      {
-        name: "'./c.module.css' in a.module.css",
-        file: iff.paths['a.module.css'],
-        line: 2,
-        offset: 33,
-        expected: [
-          { file: formatPath(iff.paths['c.module.css']), start: { line: 1, offset: 1 }, end: { line: 1, offset: 1 } },
-        ],
-      },
-      {
-        name: 'a_1 in index.ts',
-        file: iff.paths['index.ts'],
-        line: 2,
-        offset: 8,
-        expected: [
-          {
-            file: formatPath(iff.paths['a.module.css']),
-            start: { line: 3, offset: 2 },
-            end: { line: 3, offset: 5 },
-            contextStart: { line: 3, offset: 1 },
-            contextEnd: { line: 3, offset: 21 },
-          },
-        ],
-      },
-      {
-        name: 'a_2 in index.ts',
-        file: iff.paths['index.ts'],
-        line: 3,
-        offset: 8,
-        expected: [
-          {
-            file: formatPath(iff.paths['a.module.css']),
-            start: { line: 4, offset: 2 },
-            end: { line: 4, offset: 5 },
-            contextStart: { line: 4, offset: 1 },
-            contextEnd: { line: 4, offset: 21 },
-          },
-          {
-            file: formatPath(iff.paths['a.module.css']),
-            start: { line: 5, offset: 2 },
-            end: { line: 5, offset: 5 },
-            contextStart: { line: 5, offset: 1 },
-            contextEnd: { line: 5, offset: 21 },
-          },
-        ],
-      },
-      {
-        name: 'a_2 in a.module.ts',
-        file: iff.paths['a.module.css'],
-        line: 4,
-        offset: 2,
-        expected: [
-          {
-            file: formatPath(iff.paths['a.module.css']),
-            start: { line: 4, offset: 2 },
-            end: { line: 4, offset: 5 },
-            contextStart: { line: 4, offset: 1 },
-            contextEnd: { line: 4, offset: 21 },
-          },
-          {
-            file: formatPath(iff.paths['a.module.css']),
-            start: { line: 5, offset: 2 },
-            end: { line: 5, offset: 5 },
-            contextStart: { line: 5, offset: 1 },
-            contextEnd: { line: 5, offset: 21 },
-          },
-        ],
-      },
-      {
-        name: 'a_3 in index.ts',
-        file: iff.paths['index.ts'],
-        line: 4,
-        offset: 8,
-        expected: [
-          {
-            file: formatPath(iff.paths['a.module.css']),
-            start: { line: 6, offset: 8 },
-            end: { line: 6, offset: 11 },
-            contextStart: { line: 6, offset: 1 },
-            contextEnd: { line: 6, offset: 16 },
-          },
-        ],
-      },
-      {
-        name: 'a-4 in index.ts',
-        file: iff.paths['index.ts'],
-        line: 5,
-        offset: 8,
-        expected: [
-          {
-            file: formatPath(iff.paths['a.module.css']),
-            start: { line: 7, offset: 2 },
-            end: { line: 7, offset: 5 },
-            contextStart: { line: 7, offset: 1 },
-            contextEnd: { line: 7, offset: 21 },
-          },
-        ],
-      },
-      {
-        name: 'a-4 in a.module.css',
-        file: iff.paths['a.module.css'],
-        line: 7,
-        offset: 2,
-        expected: [
-          {
-            file: formatPath(iff.paths['a.module.css']),
-            start: { line: 7, offset: 2 },
-            end: { line: 7, offset: 5 },
-            contextStart: { line: 7, offset: 1 },
-            contextEnd: { line: 7, offset: 21 },
-          },
-        ],
-      },
-      {
-        name: 'b_1 in index.ts',
-        file: iff.paths['index.ts'],
-        line: 6,
-        offset: 8,
-        expected: [
+        ...getLoc('a.module.css', "'./b.module.css'"),
+      });
+
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
           {
             file: formatPath(iff.paths['b.module.css']),
-            start: { line: 1, offset: 2 },
-            end: { line: 1, offset: 5 },
-            contextStart: { line: 1, offset: 1 },
-            contextEnd: { line: 1, offset: 21 },
+            start: { line: 1, offset: 1 },
+            end: { line: 1, offset: 1 },
           },
-        ],
-      },
-      {
-        name: 'c_1 in index.ts',
-        file: iff.paths['index.ts'],
-        line: 7,
-        offset: 8,
-        expected: [
-          {
-            file: formatPath(iff.paths['c.module.css']),
-            start: { line: 1, offset: 8 },
-            end: { line: 1, offset: 11 },
-            contextStart: { line: 1, offset: 1 },
-            contextEnd: { line: 1, offset: 16 },
-          },
-        ],
-      },
-      {
-        name: 'c_1 in a.module.ts',
-        file: iff.paths['a.module.css'],
-        line: 2,
-        offset: 8,
-        expected: [
-          {
-            file: formatPath(iff.paths['c.module.css']),
-            start: { line: 1, offset: 8 },
-            end: { line: 1, offset: 11 },
-            contextStart: { line: 1, offset: 1 },
-            contextEnd: { line: 1, offset: 16 },
-          },
-        ],
-      },
-      {
-        name: 'c_alias in index.ts',
-        file: iff.paths['index.ts'],
-        line: 8,
-        offset: 8,
-        expected: [
-          {
-            file: formatPath(iff.paths['c.module.css']),
-            start: { line: 2, offset: 8 },
-            end: { line: 2, offset: 11 },
-            contextStart: { line: 2, offset: 1 },
-            contextEnd: { line: 2, offset: 16 },
-          },
-        ],
-      },
-      {
-        name: 'c_alias in a.module.css',
-        file: iff.paths['a.module.css'],
-        line: 2,
-        offset: 20,
-        expected: [
-          {
-            file: formatPath(iff.paths['c.module.css']),
-            start: { line: 2, offset: 8 },
-            end: { line: 2, offset: 11 },
-            contextStart: { line: 2, offset: 1 },
-            contextEnd: { line: 2, offset: 16 },
-          },
-        ],
-      },
-      {
-        name: 'c_2 in a.module.css',
-        file: iff.paths['a.module.css'],
-        line: 2,
-        offset: 13,
-        expected: [
-          {
-            file: formatPath(iff.paths['c.module.css']),
-            start: { line: 2, offset: 8 },
-            end: { line: 2, offset: 11 },
-            contextStart: { line: 2, offset: 1 },
-            contextEnd: { line: 2, offset: 16 },
-          },
-        ],
-      },
-      {
-        // NOTE: It is strange that `(` has a definition, but we allow it to keep the implementation simple.
-        name: '(./b.module.css) in a.module.css',
-        file: iff.paths['a.module.css'],
-        line: 8,
-        offset: 12,
-        expected: [
-          { file: formatPath(iff.paths['b.module.css']), start: { line: 1, offset: 1 }, end: { line: 1, offset: 1 } },
-        ],
-      },
-    ])('Go to Definition for $name', async ({ file, line, offset, expected }) => {
-      const res = await tsserver.sendDefinitionAndBoundSpan({
-        file,
-        line,
-        offset,
-      });
-      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(normalizeDefinitions(expected));
+        ]),
+      );
     });
-  },
-);
+
+    test('from the @value ... from specifier string', async () => {
+      const { iff, getLoc } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': buildStylesImport('./a.module.css', { namedExports }),
+        'a.module.css': `@value b_1 from './b.module.css';`,
+        'b.module.css': `@value b_1: red;`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', "'./b.module.css'"),
+      });
+
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            start: { line: 1, offset: 1 },
+            end: { line: 1, offset: 1 },
+          },
+        ]),
+      );
+    });
+
+    // NOTE: It is strange that `(` has a definition, but we allow it to keep the implementation simple.
+    test('from inside the @import url(...) parenthesis', async () => {
+      const { iff, getLoc } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': buildStylesImport('./a.module.css', { namedExports }),
+        'a.module.css': `@import url(./b.module.css);`,
+        'b.module.css': '',
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', '(./b.module.css)'),
+      });
+
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            start: { line: 1, offset: 1 },
+            end: { line: 1, offset: 1 },
+          },
+        ]),
+      );
+    });
+  });
+
+  describe('jumps to a local token declaration', () => {
+    test('from styles.<token> access', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': dedent`
+          ${buildStylesImport('./a.module.css', { namedExports })}
+          styles.a_1;
+        `,
+        'a.module.css': `.a_1 { color: red; }`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['index.ts'],
+        ...getLoc('index.ts', 'a_1'),
+      });
+
+      const { start: contextStart, end: contextEnd } = getRange('a.module.css', '.a_1 { color: red; }');
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['a.module.css']),
+            ...getRange('a.module.css', 'a_1'),
+            contextStart,
+            contextEnd,
+          },
+        ]),
+      );
+    });
+
+    test('from styles[<kebab-case token>] access', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': dedent`
+          ${buildStylesImport('./a.module.css', { namedExports })}
+          styles['a-1'];
+        `,
+        'a.module.css': `.a-1 { color: red; }`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['index.ts'],
+        ...getLoc('index.ts', 'a-1'),
+      });
+
+      const { start: contextStart, end: contextEnd } = getRange('a.module.css', '.a-1 { color: red; }');
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['a.module.css']),
+            ...getRange('a.module.css', 'a-1'),
+            contextStart,
+            contextEnd,
+          },
+        ]),
+      );
+    });
+
+    test('returns all declarations when the same class is declared multiple times', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': dedent`
+          ${buildStylesImport('./a.module.css', { namedExports })}
+          styles.a_1;
+        `,
+        'a.module.css': dedent`
+          .a_1 { color: red; }
+          .a_1 { color: red; }
+        `,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['index.ts'],
+        ...getLoc('index.ts', 'a_1'),
+      });
+
+      const decl1Range = getRange('a.module.css', '.a_1 { color: red; }', 0);
+      const decl2Range = getRange('a.module.css', '.a_1 { color: red; }', 1);
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['a.module.css']),
+            ...getRange('a.module.css', 'a_1', 0),
+            contextStart: decl1Range.start,
+            contextEnd: decl1Range.end,
+          },
+          {
+            file: formatPath(iff.paths['a.module.css']),
+            ...getRange('a.module.css', 'a_1', 1),
+            contextStart: decl2Range.start,
+            contextEnd: decl2Range.end,
+          },
+        ]),
+      );
+    });
+  });
+
+  describe('transitively resolves a re-export to its source declaration', () => {
+    test('class re-exported via @import', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': dedent`
+          ${buildStylesImport('./a.module.css', { namedExports })}
+          styles.b_1;
+        `,
+        'a.module.css': `@import './b.module.css';`,
+        'b.module.css': `.b_1 { color: red; }`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['index.ts'],
+        ...getLoc('index.ts', 'b_1'),
+      });
+
+      const { start: contextStart, end: contextEnd } = getRange('b.module.css', '.b_1 { color: red; }');
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            ...getRange('b.module.css', 'b_1'),
+            contextStart,
+            contextEnd,
+          },
+        ]),
+      );
+    });
+
+    test('value re-exported via @value ... from', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': dedent`
+          ${buildStylesImport('./a.module.css', { namedExports })}
+          styles.b_1;
+        `,
+        'a.module.css': `@value b_1 from './b.module.css';`,
+        'b.module.css': `@value b_1: red;`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['index.ts'],
+        ...getLoc('index.ts', 'b_1'),
+      });
+
+      const { start: contextStart, end: contextEnd } = getRange('b.module.css', '@value b_1: red');
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            ...getRange('b.module.css', 'b_1'),
+            contextStart,
+            contextEnd,
+          },
+        ]),
+      );
+    });
+
+    test('aliased value re-exported via @value ... from', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': dedent`
+          ${buildStylesImport('./a.module.css', { namedExports })}
+          styles.a_alias;
+        `,
+        'a.module.css': `@value b_1 as a_alias from './b.module.css';`,
+        'b.module.css': `@value b_1: red;`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['index.ts'],
+        ...getLoc('index.ts', 'a_alias'),
+      });
+
+      const { start: contextStart, end: contextEnd } = getRange('b.module.css', '@value b_1: red');
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            ...getRange('b.module.css', 'b_1'),
+            contextStart,
+            contextEnd,
+          },
+        ]),
+      );
+    });
+  });
+
+  describe('jumps from a CSS-side @value ... from binding to its source declaration', () => {
+    test('from the import binding', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': `@value b_1 from './b.module.css';`,
+        'b.module.css': `@value b_1: red;`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'b_1'),
+      });
+
+      const { start: contextStart, end: contextEnd } = getRange('b.module.css', '@value b_1: red');
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            ...getRange('b.module.css', 'b_1'),
+            contextStart,
+            contextEnd,
+          },
+        ]),
+      );
+    });
+
+    test('from the alias name in `name as alias`', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': `@value b_1 as a_alias from './b.module.css';`,
+        'b.module.css': `@value b_1: red;`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'a_alias'),
+      });
+
+      const { start: contextStart, end: contextEnd } = getRange('b.module.css', '@value b_1: red');
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            ...getRange('b.module.css', 'b_1'),
+            contextStart,
+            contextEnd,
+          },
+        ]),
+      );
+    });
+
+    test('from the source name in `name as alias`', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': `@value b_1 as a_alias from './b.module.css';`,
+        'b.module.css': `@value b_1: red;`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'b_1'),
+      });
+
+      const { start: contextStart, end: contextEnd } = getRange('b.module.css', '@value b_1: red');
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            ...getRange('b.module.css', 'b_1'),
+            contextStart,
+            contextEnd,
+          },
+        ]),
+      );
+    });
+  });
+});

--- a/packages/ts-plugin/e2e-test/test-util/fixture.ts
+++ b/packages/ts-plugin/e2e-test/test-util/fixture.ts
@@ -1,10 +1,103 @@
 import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from '@css-modules-kit/core';
-import { defineIFFCreator } from '@mizdra/inline-fixture-files';
+import { type CreateIFFResult, defineIFFCreator } from '@mizdra/inline-fixture-files';
 
 const fixtureDir = join(tmpdir(), '@css-modules-kit/ts-plugin', process.env['VITEST_POOL_ID']!);
 export const createIFF = defineIFFCreator({
   generateRootDir: () => join(fixtureDir, randomUUID()),
   unixStylePath: true,
 });
+
+export type Loc = { line: number; offset: number };
+
+function findAllMatches(content: string, search: string): number[] {
+  if (search.length === 0) throw new Error('Empty search string is not allowed.');
+  const matches: number[] = [];
+  let pos = content.indexOf(search);
+  while (pos !== -1) {
+    matches.push(pos);
+    pos = content.indexOf(search, pos + 1);
+  }
+  return matches;
+}
+
+function offsetToLoc(content: string, offset: number): Loc {
+  const before = content.slice(0, offset);
+  const newlineCount = (before.match(/\n/g) ?? []).length;
+  const lastNewline = before.lastIndexOf('\n');
+  return {
+    line: newlineCount + 1,
+    offset: before.length - (lastNewline + 1) + 1,
+  };
+}
+
+type Files = Record<string, string>;
+
+export interface SetupFixtureResult<T extends Files> {
+  iff: CreateIFFResult<T>;
+  /**
+   * Get the (1-based) line/offset of the first character of `search` in `file`.
+   *
+   * - If `search` matches exactly once, returns that position.
+   * - If `search` matches multiple times, an `index` (0-based) must be passed.
+   * - Throws if `search` does not match, or `index` is out of range.
+   */
+  getLoc: (file: string, search: string, index?: number) => Loc;
+  /**
+   * Get the (1-based) start/end range of `search` in `file`.
+   *
+   * - `start` is identical to `getLoc(file, search, index)`.
+   * - `end` points to the position immediately AFTER the last character of `search`
+   *   (exclusive end, matching tsserver's convention).
+   * - Same matching/error semantics as `getLoc`.
+   */
+  getRange: (file: string, search: string, index?: number) => { start: Loc; end: Loc };
+}
+
+export async function setupFixture<const T extends Files>(files: T): Promise<SetupFixtureResult<T>> {
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const iff = (await createIFF(files)) as any;
+
+  function getLoc(file: string, search: string, index?: number): Loc {
+    const content = files[file];
+    if (content === undefined) {
+      throw new Error(`File "${file}" was not registered in the fixture.`);
+    }
+    const matches = findAllMatches(content, search);
+    if (matches.length === 0) {
+      throw new Error(`Substring ${JSON.stringify(search)} not found in "${file}".`);
+    }
+    if (matches.length > 1 && index === undefined) {
+      throw new Error(
+        `Substring ${JSON.stringify(search)} matches ${matches.length} times in "${file}". ` +
+          `Pass a 0-based index as the third argument to disambiguate.`,
+      );
+    }
+    const target = matches[index ?? 0];
+    if (target === undefined) {
+      throw new Error(
+        `Index ${index} is out of bounds (only ${matches.length} matches of ${JSON.stringify(search)} in "${file}").`,
+      );
+    }
+    return offsetToLoc(content, target);
+  }
+
+  function getRange(file: string, search: string, index?: number): { start: Loc; end: Loc } {
+    const start = getLoc(file, search, index);
+    const lines = search.split('\n');
+    if (lines.length === 1) {
+      return { start, end: { line: start.line, offset: start.offset + search.length } };
+    }
+    const lastLine = lines[lines.length - 1] ?? '';
+    return {
+      start,
+      end: {
+        line: start.line + lines.length - 1,
+        offset: lastLine.length + 1,
+      },
+    };
+  }
+
+  return { iff, getLoc, getRange };
+}

--- a/packages/ts-plugin/test/builder.ts
+++ b/packages/ts-plugin/test/builder.ts
@@ -1,0 +1,18 @@
+interface TSConfig {
+  compilerOptions?: Record<string, unknown>;
+  cmkOptions?: Record<string, unknown>;
+}
+
+export function buildTSConfigJSON(args?: TSConfig): string {
+  return JSON.stringify({
+    ...(args?.compilerOptions ? { compilerOptions: args.compilerOptions } : {}),
+    cmkOptions: {
+      enabled: true,
+      ...args?.cmkOptions,
+    },
+  });
+}
+
+export function buildStylesImport(specifier: string, { namedExports }: { namedExports: boolean }): string {
+  return namedExports ? `import * as styles from '${specifier}';` : `import styles from '${specifier}';`;
+}


### PR DESCRIPTION
## Summary

Refactor `packages/ts-plugin/e2e-test/feature/go-to-definition.test.ts` so that each `test` block owns a minimal fixture and asserts a single behavior, organized by the .d.ts/mapping pattern under test. The previous structure shared one large fixture (5 files, 8+ tokens) across 17 cases inside a single `test.each`, which made it brittle to add new behaviors.

This is the first PR of a multi-PR series. Subsequent PRs will apply the same approach to the other `e2e-test/` files (find-all-references, rename-symbol, completion, etc.).

## What's new

- **`packages/ts-plugin/e2e-test/test-util/fixture.ts`**: adds
  - `setupFixture(files)` — mirrors `createIFF`'s shape; callers pass files directly (including `tsconfig.json`), so each test can place its config wherever it likes.
  - `getLoc(file, search, index?)` — 1-based line/offset of the first character of `search` in `file`. Throws if `search` is ambiguous and `index` is omitted.
  - `getRange(file, search, index?)` — `{ start, end }` range with `end` exclusive (matches tsserver's convention).
- **`packages/ts-plugin/test/builder.ts`** (new): code-fragment builders for fixture files
  - `buildTSConfigJSON({ compilerOptions?, cmkOptions? })` — defaults `cmkOptions.enabled` to `true`.
  - `buildStylesImport(specifier, { namedExports })` — builds default / namespace `styles` import statements at call sites.
- **`packages/ts-plugin/e2e-test/feature/go-to-definition.test.ts`**: rewritten as 14 behavior-focused tests, each with its own minimal fixture, organized into 4 `describe` blocks. Each fixture uses contiguous token / filename numbering (e.g. `a.module.css` + `b.module.css`, `.a-1`, `b_1`) so it only references the files and tokens the test actually needs.

## Test structure

Each describe corresponds to a distinct .d.ts/mapping pattern produced by `dts-generator.ts`:

```
namedExports: $namedExports
├── jumps to the top of a CSS module file (5 tests)
│   ├── from the styles binding in the import statement
│   ├── from the import specifier string
│   ├── from the @import specifier string
│   ├── from the @value ... from specifier string
│   └── from inside the @import url(...) parenthesis
├── jumps to a local token declaration (3 tests)
│   ├── from styles.<token> access
│   ├── from styles[<kebab-case token>] access
│   └── returns all declarations when the same class is declared multiple times
├── transitively resolves a re-export to its source declaration (3 tests)
│   ├── class re-exported via @import
│   ├── value re-exported via @value ... from
│   └── aliased value re-exported via @value ... from
└── jumps from a CSS-side @value ... from binding to its source declaration (3 tests)
    ├── from the import binding
    ├── from the alias name in \`name as alias\`
    └── from the source name in \`name as alias\`
```

Total: **14 tests × 2 variants (`namedExports: false / true`) = 28 tests**.

Per-syntax parser coverage (e.g. `.foo`, `@value foo: red;`, `@keyframes foo`) lives in `dts-generator.test.ts`; here we only cover one representative for each .d.ts/mapping pattern.

## Test plan

- [x] `vp test --project e2e packages/ts-plugin/e2e-test/feature/go-to-definition.test.ts` — 28 passed
- [x] `vp test --project e2e` (full e2e suite) — no regressions
- [x] `vp check` (format + lint + type) — pass