### PR TITLE
fix(core): use alias name for re-exported tokens via `@value ... as ... from ...`

### DIFF
--- a/.changeset/fix-aliased-reexport-in-export-record.md
+++ b/.changeset/fix-aliased-reexport-in-export-record.md
@@ -1,0 +1,7 @@
+---
+'@css-modules-kit/core': patch
+---
+
+fix(core): use the alias name when collecting re-exported tokens via `@value ... as ... from ...`
+
+`createExportBuilder` was recording the source-side name (`entry.name`) into the importing module's `ExportRecord` instead of the alias the importing module actually exposes (`entry.localName`). This caused downstream consumers to look up the wrong name, e.g. `checkCSSModule` would emit a false "no exported token" diagnostic for an aliased token re-imported from another module.

--- a/packages/core/src/export-builder.test.ts
+++ b/packages/core/src/export-builder.test.ts
@@ -82,6 +82,21 @@ describe('ExportBuilder', () => {
       }
     `);
   });
+  test('use the alias name when `@value ... as ... from ...` re-exports a token', async () => {
+    const iff = await createIFF({
+      'a.module.css': `@value b_1 as b_alias from './b.module.css';`,
+      'b.module.css': `@value b_1: red;`,
+    });
+    const exportBuilder = prepareExportBuilder();
+    const cssModule = readAndParseCSSModule(iff.paths['a.module.css'])!;
+    expect(exportBuilder.build(cssModule)).toMatchInlineSnapshot(`
+      {
+        "allTokens": [
+          "b_alias",
+        ],
+      }
+    `);
+  });
   test('do not collect tokens from `@import` for unmatched or unresolvable modules', async () => {
     const iff = await createIFF({
       'a.module.css': dedent`

--- a/packages/core/src/export-builder.ts
+++ b/packages/core/src/export-builder.ts
@@ -34,7 +34,7 @@ export function createExportBuilder(host: ExportBuilderHost): ExportBuilder {
         result.allTokens.push(...importedResult.allTokens);
       } else {
         for (const entry of tokenImporter.entries) {
-          result.allTokens.push(entry.name);
+          result.allTokens.push(entry.localName ?? entry.name);
         }
       }
     }


### PR DESCRIPTION
## Summary

Fix `createExportBuilder` so that an aliased re-export (`@value name as alias from '...'`) records the **alias** name (`entry.localName`) in the importing module's `ExportRecord`, instead of the source-side name (`entry.name`).

## Reproduction

```css
/* a.module.css */
@value b_1 as b_alias from './b.module.css';

/* b.module.css */
@value b_1: red;
```

`createExportBuilder().build(a)` now returns `{ allTokens: ['b_alias'] }` (was `['b_1']`).

## Why this matters

`ExportRecord` is the source of truth for "what names does this module expose to other modules". `dts-generator` already uses `entry.localName ?? entry.name` when emitting the generated `.d.ts`, so the d.ts and the `ExportRecord` were inconsistent.

The most user-visible symptom is a false positive in `checkCSSModule`: when a third module imports the aliased name (e.g. `c.module.css` does `@value b_alias from './a.module.css';`), the checker would query `a`'s `ExportRecord`, fail to find `b_alias`, and emit a spurious `Module './a.module.css' has no exported token 'b_alias'.` diagnostic.

## Test plan

- [x] Added a unit test in `export-builder.test.ts` that exercises `@value ... as ... from ...` and asserts the alias is recorded
- [x] `vp test` — all tests pass
- [x] `vp check` — format / lint / typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)