### PR TITLE
refactor(ts-plugin): regroup e2e tests by CSSModule structure

### DIFF
--- a/packages/ts-plugin/e2e-test/find-all-references.test.ts
+++ b/packages/ts-plugin/e2e-test/find-all-references.test.ts
@@ -7,8 +7,8 @@ import { formatPath, launchTsserver, normalizeRefItems } from './test-util/tsser
 const tsserver = launchTsserver();
 
 describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: $namedExports', ({ namedExports }) => {
-  describe('finds all references to the styles binding', () => {
-    test('from the styles binding in the import statement', async () => {
+  describe('for a TS-side import statement', () => {
+    test('from the styles binding', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -38,8 +38,8 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
   });
 
-  describe('for a local token', () => {
-    test('from styles.<token>', async () => {
+  describe('for a token definition', () => {
+    test('from a TS-side styles.<token>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -63,7 +63,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from styles[<kebab-case token>]', async () => {
+    test('from a TS-side styles[<kebab-case token>]', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -87,7 +87,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from styles.<token> declared multiple times', async () => {
+    test('when the token is declared multiple times', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -140,8 +140,8 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
   });
 
-  describe('for a token importer', () => {
-    test('from styles.<token> via @import re-export', async () => {
+  describe('for an all token importer', () => {
+    test('from a TS-side styles.<token>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -165,8 +165,10 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
         ]),
       );
     });
+  });
 
-    test('from styles.<value> via @value re-export', async () => {
+  describe('for a named token importer', () => {
+    test('from a TS-side styles.<name>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -193,7 +195,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
 
     // NOTE: Ideally only `b_alias` should be returned, but `b_1` is also returned for implementation simplicity.
-    test('from styles.<alias> via @value re-export', async () => {
+    test('from a TS-side styles.<alias>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -220,7 +222,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from a CSS-side @value ... from binding', async () => {
+    test('from a CSS-side <name>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 from './b.module.css';`,
@@ -241,8 +243,8 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    // NOTE: Ideally only `b_alias` should be returned, but `b_1` is also returned for implementation simplicity.
-    test('from a CSS-side @value ... from alias name', async () => {
+    // NOTE: Ideally only `b_1` should be returned, but `b_alias` is also returned for implementation simplicity.
+    test('from a CSS-side <name> with alias', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 as b_alias from './b.module.css';`,
@@ -252,7 +254,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
 
       const res = await tsserver.sendReferences({
         file: iff.paths['a.module.css'],
-        ...getLoc('a.module.css', 'b_alias'),
+        ...getLoc('a.module.css', 'b_1'),
       });
 
       expect(normalizeRefItems(res.body?.refs ?? [])).toStrictEqual(
@@ -264,8 +266,8 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    // NOTE: Ideally only `b_1` should be returned, but `b_alias` is also returned for implementation simplicity.
-    test('from a CSS-side @value ... from source name', async () => {
+    // NOTE: Ideally only `b_alias` should be returned, but `b_1` is also returned for implementation simplicity.
+    test('from a CSS-side <alias>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 as b_alias from './b.module.css';`,
@@ -275,7 +277,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
 
       const res = await tsserver.sendReferences({
         file: iff.paths['a.module.css'],
-        ...getLoc('a.module.css', 'b_1'),
+        ...getLoc('a.module.css', 'b_alias'),
       });
 
       expect(normalizeRefItems(res.body?.refs ?? [])).toStrictEqual(

--- a/packages/ts-plugin/e2e-test/find-all-references.test.ts
+++ b/packages/ts-plugin/e2e-test/find-all-references.test.ts
@@ -38,8 +38,8 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
   });
 
-  describe('finds all references to a local token', () => {
-    test('from styles.<token> access', async () => {
+  describe('for a local token', () => {
+    test('from styles.<token>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -63,7 +63,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from styles[<kebab-case token>] access', async () => {
+    test('from styles[<kebab-case token>]', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -87,7 +87,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('when the same class is declared multiple times', async () => {
+    test('from styles.<token> declared multiple times', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -114,10 +114,34 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
         ]),
       );
     });
+
+    test('from a CSS-side class declaration', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': dedent`
+          ${buildStylesImport('./a.module.css', { namedExports })}
+          styles.a_1;
+        `,
+        'a.module.css': `.a_1 { color: red; }`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendReferences({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'a_1'),
+      });
+
+      expect(normalizeRefItems(res.body?.refs ?? [])).toStrictEqual(
+        normalizeRefItems([
+          { file: formatPath(iff.paths['index.ts']), ...getRange('index.ts', 'a_1') },
+          { file: formatPath(iff.paths['a.module.css']), ...getRange('a.module.css', 'a_1') },
+        ]),
+      );
+    });
   });
 
-  describe('transitively resolves a re-export to its source declaration', () => {
-    test('class re-exported via @import', async () => {
+  describe('for a token importer', () => {
+    test('from styles.<token> via @import re-export', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -142,7 +166,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('value re-exported via @value ... from', async () => {
+    test('from styles.<value> via @value re-export', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -169,7 +193,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
 
     // NOTE: Ideally only `b_alias` should be returned, but `b_1` is also returned for implementation simplicity.
-    test('aliased value re-exported via @value ... from', async () => {
+    test('from styles.<alias> via @value re-export', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -195,36 +219,8 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
         ]),
       );
     });
-  });
 
-  describe('finds all references from a CSS-side class declaration', () => {
-    test('from a .<token> declaration', async () => {
-      const { iff, getLoc, getRange } = await setupFixture({
-        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
-        'index.ts': dedent`
-          ${buildStylesImport('./a.module.css', { namedExports })}
-          styles.a_1;
-        `,
-        'a.module.css': `.a_1 { color: red; }`,
-      });
-      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
-
-      const res = await tsserver.sendReferences({
-        file: iff.paths['a.module.css'],
-        ...getLoc('a.module.css', 'a_1'),
-      });
-
-      expect(normalizeRefItems(res.body?.refs ?? [])).toStrictEqual(
-        normalizeRefItems([
-          { file: formatPath(iff.paths['index.ts']), ...getRange('index.ts', 'a_1') },
-          { file: formatPath(iff.paths['a.module.css']), ...getRange('a.module.css', 'a_1') },
-        ]),
-      );
-    });
-  });
-
-  describe('finds all references from a CSS-side @value ... from binding', () => {
-    test('from the import binding', async () => {
+    test('from a CSS-side @value ... from binding', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 from './b.module.css';`,
@@ -246,7 +242,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
 
     // NOTE: Ideally only `b_alias` should be returned, but `b_1` is also returned for implementation simplicity.
-    test('from the alias name in `name as alias`', async () => {
+    test('from a CSS-side @value ... from alias name', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 as b_alias from './b.module.css';`,
@@ -269,7 +265,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
 
     // NOTE: Ideally only `b_1` should be returned, but `b_alias` is also returned for implementation simplicity.
-    test('from the source name in `name as alias`', async () => {
+    test('from a CSS-side @value ... from source name', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 as b_alias from './b.module.css';`,

--- a/packages/ts-plugin/e2e-test/find-all-references.test.ts
+++ b/packages/ts-plugin/e2e-test/find-all-references.test.ts
@@ -115,7 +115,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from a CSS-side class declaration', async () => {
+    test('from a CSS-side token definition', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`

--- a/packages/ts-plugin/e2e-test/go-to-definition.test.ts
+++ b/packages/ts-plugin/e2e-test/go-to-definition.test.ts
@@ -133,8 +133,8 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
   });
 
-  describe('jumps to a local token declaration', () => {
-    test('from styles.<token> access', async () => {
+  describe('for a local token', () => {
+    test('from styles.<token>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -163,7 +163,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from styles[<kebab-case token>] access', async () => {
+    test('from styles[<kebab-case token>]', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -192,7 +192,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('when the same class is declared multiple times', async () => {
+    test('from styles.<token> declared multiple times', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -230,102 +230,8 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
         ]),
       );
     });
-  });
 
-  describe('transitively resolves a re-export to its source declaration', () => {
-    test('class re-exported via @import', async () => {
-      const { iff, getLoc, getRange } = await setupFixture({
-        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
-        'index.ts': dedent`
-          ${buildStylesImport('./a.module.css', { namedExports })}
-          styles.b_1;
-        `,
-        'a.module.css': `@import './b.module.css';`,
-        'b.module.css': `.b_1 { color: red; }`,
-      });
-      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
-
-      const res = await tsserver.sendDefinitionAndBoundSpan({
-        file: iff.paths['index.ts'],
-        ...getLoc('index.ts', 'b_1'),
-      });
-
-      const { start: contextStart, end: contextEnd } = getRange('b.module.css', '.b_1 { color: red; }');
-      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
-        normalizeDefinitions([
-          {
-            file: formatPath(iff.paths['b.module.css']),
-            ...getRange('b.module.css', 'b_1'),
-            contextStart,
-            contextEnd,
-          },
-        ]),
-      );
-    });
-
-    test('value re-exported via @value ... from', async () => {
-      const { iff, getLoc, getRange } = await setupFixture({
-        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
-        'index.ts': dedent`
-          ${buildStylesImport('./a.module.css', { namedExports })}
-          styles.b_1;
-        `,
-        'a.module.css': `@value b_1 from './b.module.css';`,
-        'b.module.css': `@value b_1: red;`,
-      });
-      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
-
-      const res = await tsserver.sendDefinitionAndBoundSpan({
-        file: iff.paths['index.ts'],
-        ...getLoc('index.ts', 'b_1'),
-      });
-
-      const { start: contextStart, end: contextEnd } = getRange('b.module.css', '@value b_1: red');
-      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
-        normalizeDefinitions([
-          {
-            file: formatPath(iff.paths['b.module.css']),
-            ...getRange('b.module.css', 'b_1'),
-            contextStart,
-            contextEnd,
-          },
-        ]),
-      );
-    });
-
-    test('aliased value re-exported via @value ... from', async () => {
-      const { iff, getLoc, getRange } = await setupFixture({
-        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
-        'index.ts': dedent`
-          ${buildStylesImport('./a.module.css', { namedExports })}
-          styles.b_alias;
-        `,
-        'a.module.css': `@value b_1 as b_alias from './b.module.css';`,
-        'b.module.css': `@value b_1: red;`,
-      });
-      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
-
-      const res = await tsserver.sendDefinitionAndBoundSpan({
-        file: iff.paths['index.ts'],
-        ...getLoc('index.ts', 'b_alias'),
-      });
-
-      const { start: contextStart, end: contextEnd } = getRange('b.module.css', '@value b_1: red');
-      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
-        normalizeDefinitions([
-          {
-            file: formatPath(iff.paths['b.module.css']),
-            ...getRange('b.module.css', 'b_1'),
-            contextStart,
-            contextEnd,
-          },
-        ]),
-      );
-    });
-  });
-
-  describe('jumps from a CSS-side class declaration', () => {
-    test('from a .<token> declaration', async () => {
+    test('from a CSS-side class declaration', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -355,8 +261,98 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
   });
 
-  describe('jumps from a CSS-side @value ... from binding to its source declaration', () => {
-    test('from the import binding', async () => {
+  describe('for a token importer', () => {
+    test('from styles.<token> via @import re-export', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': dedent`
+          ${buildStylesImport('./a.module.css', { namedExports })}
+          styles.b_1;
+        `,
+        'a.module.css': `@import './b.module.css';`,
+        'b.module.css': `.b_1 { color: red; }`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['index.ts'],
+        ...getLoc('index.ts', 'b_1'),
+      });
+
+      const { start: contextStart, end: contextEnd } = getRange('b.module.css', '.b_1 { color: red; }');
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            ...getRange('b.module.css', 'b_1'),
+            contextStart,
+            contextEnd,
+          },
+        ]),
+      );
+    });
+
+    test('from styles.<value> via @value re-export', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': dedent`
+          ${buildStylesImport('./a.module.css', { namedExports })}
+          styles.b_1;
+        `,
+        'a.module.css': `@value b_1 from './b.module.css';`,
+        'b.module.css': `@value b_1: red;`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['index.ts'],
+        ...getLoc('index.ts', 'b_1'),
+      });
+
+      const { start: contextStart, end: contextEnd } = getRange('b.module.css', '@value b_1: red');
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            ...getRange('b.module.css', 'b_1'),
+            contextStart,
+            contextEnd,
+          },
+        ]),
+      );
+    });
+
+    test('from styles.<alias> via @value re-export', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': dedent`
+          ${buildStylesImport('./a.module.css', { namedExports })}
+          styles.b_alias;
+        `,
+        'a.module.css': `@value b_1 as b_alias from './b.module.css';`,
+        'b.module.css': `@value b_1: red;`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['index.ts'],
+        ...getLoc('index.ts', 'b_alias'),
+      });
+
+      const { start: contextStart, end: contextEnd } = getRange('b.module.css', '@value b_1: red');
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            ...getRange('b.module.css', 'b_1'),
+            contextStart,
+            contextEnd,
+          },
+        ]),
+      );
+    });
+
+    test('from a CSS-side @value ... from binding', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 from './b.module.css';`,
@@ -382,7 +378,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from the alias name in `name as alias`', async () => {
+    test('from a CSS-side @value ... from alias name', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 as b_alias from './b.module.css';`,
@@ -408,7 +404,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from the source name in `name as alias`', async () => {
+    test('from a CSS-side @value ... from source name', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 as b_alias from './b.module.css';`,

--- a/packages/ts-plugin/e2e-test/go-to-definition.test.ts
+++ b/packages/ts-plugin/e2e-test/go-to-definition.test.ts
@@ -7,8 +7,8 @@ import { formatPath, launchTsserver, normalizeDefinitions } from './test-util/ts
 const tsserver = launchTsserver();
 
 describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: $namedExports', ({ namedExports }) => {
-  describe('jumps to the top of a CSS module file', () => {
-    test('from the styles binding in the import statement', async () => {
+  describe('for a TS-side import statement', () => {
+    test('from the styles binding', async () => {
       const { iff, getLoc } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': buildStylesImport('./a.module.css', { namedExports }),
@@ -32,7 +32,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from the import specifier string', async () => {
+    test('from the import specifier', async () => {
       const { iff, getLoc } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': buildStylesImport('./a.module.css', { namedExports }),
@@ -55,86 +55,10 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
         ]),
       );
     });
-
-    test('from the @import specifier string', async () => {
-      const { iff, getLoc } = await setupFixture({
-        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
-        'index.ts': buildStylesImport('./a.module.css', { namedExports }),
-        'a.module.css': `@import './b.module.css';`,
-        'b.module.css': '',
-      });
-      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
-
-      const res = await tsserver.sendDefinitionAndBoundSpan({
-        file: iff.paths['a.module.css'],
-        ...getLoc('a.module.css', "'./b.module.css'"),
-      });
-
-      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
-        normalizeDefinitions([
-          {
-            file: formatPath(iff.paths['b.module.css']),
-            start: { line: 1, offset: 1 },
-            end: { line: 1, offset: 1 },
-          },
-        ]),
-      );
-    });
-
-    test('from the @value ... from specifier string', async () => {
-      const { iff, getLoc } = await setupFixture({
-        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
-        'index.ts': buildStylesImport('./a.module.css', { namedExports }),
-        'a.module.css': `@value b_1 from './b.module.css';`,
-        'b.module.css': `@value b_1: red;`,
-      });
-      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
-
-      const res = await tsserver.sendDefinitionAndBoundSpan({
-        file: iff.paths['a.module.css'],
-        ...getLoc('a.module.css', "'./b.module.css'"),
-      });
-
-      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
-        normalizeDefinitions([
-          {
-            file: formatPath(iff.paths['b.module.css']),
-            start: { line: 1, offset: 1 },
-            end: { line: 1, offset: 1 },
-          },
-        ]),
-      );
-    });
-
-    // NOTE: It is strange that `(` has a definition, but we allow it to keep the implementation simple.
-    test('from inside the @import url(...) parenthesis', async () => {
-      const { iff, getLoc } = await setupFixture({
-        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
-        'index.ts': buildStylesImport('./a.module.css', { namedExports }),
-        'a.module.css': `@import url(./b.module.css);`,
-        'b.module.css': '',
-      });
-      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
-
-      const res = await tsserver.sendDefinitionAndBoundSpan({
-        file: iff.paths['a.module.css'],
-        ...getLoc('a.module.css', '(./b.module.css)'),
-      });
-
-      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
-        normalizeDefinitions([
-          {
-            file: formatPath(iff.paths['b.module.css']),
-            start: { line: 1, offset: 1 },
-            end: { line: 1, offset: 1 },
-          },
-        ]),
-      );
-    });
   });
 
-  describe('for a local token', () => {
-    test('from styles.<token>', async () => {
+  describe('for a token definition', () => {
+    test('from a TS-side styles.<token>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -163,7 +87,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from styles[<kebab-case token>]', async () => {
+    test('from a TS-side styles[<kebab-case token>]', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -192,7 +116,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from styles.<token> declared multiple times', async () => {
+    test('when the token is declared multiple times', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -261,8 +185,8 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
   });
 
-  describe('for a token importer', () => {
-    test('from styles.<token> via @import re-export', async () => {
+  describe('for an all token importer', () => {
+    test('from a TS-side styles.<token>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -292,7 +216,60 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from styles.<value> via @value re-export', async () => {
+    test('from a CSS-side specifier', async () => {
+      const { iff, getLoc } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': buildStylesImport('./a.module.css', { namedExports }),
+        'a.module.css': `@import './b.module.css';`,
+        'b.module.css': '',
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', "'./b.module.css'"),
+      });
+
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            start: { line: 1, offset: 1 },
+            end: { line: 1, offset: 1 },
+          },
+        ]),
+      );
+    });
+
+    // NOTE: It is strange that `(` has a definition, but we allow it to keep the implementation simple.
+    test('from inside a CSS-side url() specifier', async () => {
+      const { iff, getLoc } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': buildStylesImport('./a.module.css', { namedExports }),
+        'a.module.css': `@import url(./b.module.css);`,
+        'b.module.css': '',
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', '(./b.module.css)'),
+      });
+
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            start: { line: 1, offset: 1 },
+            end: { line: 1, offset: 1 },
+          },
+        ]),
+      );
+    });
+  });
+
+  describe('for a named token importer', () => {
+    test('from a TS-side styles.<name>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -322,7 +299,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from styles.<alias> via @value re-export', async () => {
+    test('from a TS-side styles.<alias>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -352,7 +329,32 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from a CSS-side @value ... from binding', async () => {
+    test('from a CSS-side specifier', async () => {
+      const { iff, getLoc } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': buildStylesImport('./a.module.css', { namedExports }),
+        'a.module.css': `@value b_1 from './b.module.css';`,
+        'b.module.css': `@value b_1: red;`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', "'./b.module.css'"),
+      });
+
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            start: { line: 1, offset: 1 },
+            end: { line: 1, offset: 1 },
+          },
+        ]),
+      );
+    });
+
+    test('from a CSS-side <name>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 from './b.module.css';`,
@@ -378,7 +380,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from a CSS-side @value ... from alias name', async () => {
+    test('from a CSS-side <name> with alias', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 as b_alias from './b.module.css';`,
@@ -388,7 +390,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
 
       const res = await tsserver.sendDefinitionAndBoundSpan({
         file: iff.paths['a.module.css'],
-        ...getLoc('a.module.css', 'b_alias'),
+        ...getLoc('a.module.css', 'b_1'),
       });
 
       const { start: contextStart, end: contextEnd } = getRange('b.module.css', '@value b_1: red');
@@ -404,7 +406,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from a CSS-side @value ... from source name', async () => {
+    test('from a CSS-side <alias>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 as b_alias from './b.module.css';`,
@@ -414,7 +416,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
 
       const res = await tsserver.sendDefinitionAndBoundSpan({
         file: iff.paths['a.module.css'],
-        ...getLoc('a.module.css', 'b_1'),
+        ...getLoc('a.module.css', 'b_alias'),
       });
 
       const { start: contextStart, end: contextEnd } = getRange('b.module.css', '@value b_1: red');

--- a/packages/ts-plugin/e2e-test/go-to-definition.test.ts
+++ b/packages/ts-plugin/e2e-test/go-to-definition.test.ts
@@ -231,7 +231,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from a CSS-side class declaration', async () => {
+    test('from a CSS-side token definition', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`

--- a/packages/ts-plugin/e2e-test/rename-symbol.test.ts
+++ b/packages/ts-plugin/e2e-test/rename-symbol.test.ts
@@ -86,7 +86,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from a CSS-side class declaration', async () => {
+    test('from a CSS-side token definition', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`

--- a/packages/ts-plugin/e2e-test/rename-symbol.test.ts
+++ b/packages/ts-plugin/e2e-test/rename-symbol.test.ts
@@ -7,8 +7,8 @@ import { formatPath, launchTsserver, normalizeSpanGroups } from './test-util/tss
 const tsserver = launchTsserver();
 
 describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: $namedExports', ({ namedExports }) => {
-  describe('for a local token', () => {
-    test('from styles.<token>', async () => {
+  describe('for a token definition', () => {
+    test('from a TS-side styles.<token>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -32,7 +32,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from styles[<kebab-case token>]', async () => {
+    test('from a TS-side styles[<kebab-case token>]', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -56,7 +56,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from styles.<token> declared multiple times', async () => {
+    test('when the token is declared multiple times', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -111,8 +111,8 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
   });
 
-  describe('for a token importer', () => {
-    test('from styles.<token> via @import re-export', async () => {
+  describe('for an all token importer', () => {
+    test('from a TS-side styles.<token>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -136,11 +136,13 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
         ]),
       );
     });
+  });
 
+  describe('for a named token importer', () => {
     // NOTE: For simplicity of implementation, this is not the ideal behavior.
     // The ideal behavior would attach `prefixText: 'b_1 as '` to the binding loc in `a.module.css`
     // so that renaming changes only the alias side. Currently the binding loc is rewritten directly.
-    test('from styles.<value> via @value re-export', async () => {
+    test('from a TS-side styles.<name>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -167,7 +169,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
 
     // NOTE: Ideally only `b_alias` should be returned, but `b_1` is also returned for implementation simplicity.
-    test('from styles.<alias> via @value re-export', async () => {
+    test('from a TS-side styles.<alias>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -196,7 +198,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from a CSS-side @value ... from binding', async () => {
+    test('from a CSS-side <name>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 from './b.module.css';`,
@@ -217,8 +219,8 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    // NOTE: Ideally only `b_alias` should be returned, but `b_1` is also returned for implementation simplicity.
-    test('from a CSS-side @value ... from alias name', async () => {
+    // NOTE: Ideally only `b_1` should be returned, but `b_alias` is also returned for implementation simplicity.
+    test('from a CSS-side <name> with alias', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 as b_alias from './b.module.css';`,
@@ -228,7 +230,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
 
       const res = await tsserver.sendRename({
         file: iff.paths['a.module.css'],
-        ...getLoc('a.module.css', 'b_alias'),
+        ...getLoc('a.module.css', 'b_1'),
       });
 
       expect(normalizeSpanGroups(res.body?.locs ?? [])).toStrictEqual(
@@ -242,8 +244,8 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    // NOTE: Ideally only `b_1` should be returned, but `b_alias` is also returned for implementation simplicity.
-    test('from a CSS-side @value ... from source name', async () => {
+    // NOTE: Ideally only `b_alias` should be returned, but `b_1` is also returned for implementation simplicity.
+    test('from a CSS-side <alias>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 as b_alias from './b.module.css';`,
@@ -253,7 +255,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
 
       const res = await tsserver.sendRename({
         file: iff.paths['a.module.css'],
-        ...getLoc('a.module.css', 'b_1'),
+        ...getLoc('a.module.css', 'b_alias'),
       });
 
       expect(normalizeSpanGroups(res.body?.locs ?? [])).toStrictEqual(

--- a/packages/ts-plugin/e2e-test/rename-symbol.test.ts
+++ b/packages/ts-plugin/e2e-test/rename-symbol.test.ts
@@ -7,8 +7,8 @@ import { formatPath, launchTsserver, normalizeSpanGroups } from './test-util/tss
 const tsserver = launchTsserver();
 
 describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: $namedExports', ({ namedExports }) => {
-  describe('renames a local token', () => {
-    test('from styles.<token> access', async () => {
+  describe('for a local token', () => {
+    test('from styles.<token>', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -32,7 +32,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from styles[<kebab-case token>] access', async () => {
+    test('from styles[<kebab-case token>]', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -56,7 +56,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('when the same class is declared multiple times', async () => {
+    test('from styles.<token> declared multiple times', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -85,10 +85,34 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
         ]),
       );
     });
+
+    test('from a CSS-side class declaration', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'index.ts': dedent`
+          ${buildStylesImport('./a.module.css', { namedExports })}
+          styles.a_1;
+        `,
+        'a.module.css': `.a_1 { color: red; }`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendRename({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'a_1'),
+      });
+
+      expect(normalizeSpanGroups(res.body?.locs ?? [])).toStrictEqual(
+        normalizeSpanGroups([
+          { file: formatPath(iff.paths['index.ts']), locs: [getRange('index.ts', 'a_1')] },
+          { file: formatPath(iff.paths['a.module.css']), locs: [getRange('a.module.css', 'a_1')] },
+        ]),
+      );
+    });
   });
 
-  describe('transitively resolves a re-export to its source declaration', () => {
-    test('class re-exported via @import', async () => {
+  describe('for a token importer', () => {
+    test('from styles.<token> via @import re-export', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -116,7 +140,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     // NOTE: For simplicity of implementation, this is not the ideal behavior.
     // The ideal behavior would attach `prefixText: 'b_1 as '` to the binding loc in `a.module.css`
     // so that renaming changes only the alias side. Currently the binding loc is rewritten directly.
-    test('value re-exported via @value ... from', async () => {
+    test('from styles.<value> via @value re-export', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -143,7 +167,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
 
     // NOTE: Ideally only `b_alias` should be returned, but `b_1` is also returned for implementation simplicity.
-    test('aliased value re-exported via @value ... from', async () => {
+    test('from styles.<alias> via @value re-export', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'index.ts': dedent`
@@ -171,36 +195,8 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
         ]),
       );
     });
-  });
 
-  describe('renames from a CSS-side class declaration', () => {
-    test('from a .<token> declaration', async () => {
-      const { iff, getLoc, getRange } = await setupFixture({
-        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
-        'index.ts': dedent`
-          ${buildStylesImport('./a.module.css', { namedExports })}
-          styles.a_1;
-        `,
-        'a.module.css': `.a_1 { color: red; }`,
-      });
-      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
-
-      const res = await tsserver.sendRename({
-        file: iff.paths['a.module.css'],
-        ...getLoc('a.module.css', 'a_1'),
-      });
-
-      expect(normalizeSpanGroups(res.body?.locs ?? [])).toStrictEqual(
-        normalizeSpanGroups([
-          { file: formatPath(iff.paths['index.ts']), locs: [getRange('index.ts', 'a_1')] },
-          { file: formatPath(iff.paths['a.module.css']), locs: [getRange('a.module.css', 'a_1')] },
-        ]),
-      );
-    });
-  });
-
-  describe('renames from a CSS-side @value ... from binding', () => {
-    test('from the import binding', async () => {
+    test('from a CSS-side @value ... from binding', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 from './b.module.css';`,
@@ -222,7 +218,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
 
     // NOTE: Ideally only `b_alias` should be returned, but `b_1` is also returned for implementation simplicity.
-    test('from the alias name in `name as alias`', async () => {
+    test('from a CSS-side @value ... from alias name', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 as b_alias from './b.module.css';`,
@@ -247,7 +243,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
 
     // NOTE: Ideally only `b_1` should be returned, but `b_alias` is also returned for implementation simplicity.
-    test('from the source name in `name as alias`', async () => {
+    test('from a CSS-side @value ... from source name', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 as b_alias from './b.module.css';`,


### PR DESCRIPTION
## Summary

Reorganize the e2e tests in `go-to-definition.test.ts`, `find-all-references.test.ts`, and `rename-symbol.test.ts` so each describe corresponds to the structural element that is the SUT (System Under Test) of its tests:

- `for a TS-side import statement` — the JS-side `import styles from '...'`
- `for a token definition` — a locally defined token (a class declaration / `@value` definition / etc.)
- `for an all token importer` — an `AllTokenImporter`, including its from-specifier and the tokens accessed through it
- `for a named token importer` — a `NamedTokenImporter`, its from-specifier, and its entries

Tests inside each describe vary by cursor sub-position. Test bodies are unchanged; only describe groupings, test names, and ordering changed. Test counts per file are unchanged (go-to-definition: 15, find-all-references: 11, rename-symbol: 10).

## Why

Previously the describes mixed CSS syntax (`@import`, `@value ... from`) with verb-form feature describes (`jumps to the top of a CSS module file`, `finds all references to the styles binding`, `transitively resolves a re-export to its source declaration`, ...). This made it hard to:

- Distinguish parser tests (which already cover CSS syntax exhaustively) from ts-plugin tests (which should test how each `CSSModule` element behaves in language features)
- Extend the suite with new token kinds (`@keyframes`, future `composes:`, etc.) without inventing new syntax-named describes
- See the type → test correspondence at a glance

After the refactor:

- All describes use `for a/the <X>` noun phrases corresponding to a single SUT
- CSS syntax (`@import`, `@value ... from`) no longer appears in describe or test names
- Test names use specifier-field semantics (`<name>` / `<alias>`) and a symmetric `TS-side` / `CSS-side` prefix in describes that mix sides

## Test plan

- [x] `vp test --project e2e packages/ts-plugin/` — all 72 tests pass
- [x] `vp check` — format / lint / typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)