### PR TITLE
test(core): visualize mappings and cover both modes in dts-generator

### DIFF
--- a/packages/core/src/dts-generator.test.ts
+++ b/packages/core/src/dts-generator.test.ts
@@ -52,10 +52,10 @@ describe('generates an empty .d.ts file when the CSS module has no tokens', () =
 
 describe('creates an entry for each local token declaration', () => {
   const source = dedent`
-      .a_1 { color: red; }
-      .a_2 { color: red; }
-      .a_2 { color: red; }
-    `;
+    .a_1 { color: red; }
+    .a_2 { color: red; }
+    .a_2 { color: red; }
+  `;
   test('default export', async () => {
     expect(await run(source, defaultExportOptions)).toMatchInlineSnapshot(`
     	"=== source ===
@@ -262,9 +262,9 @@ describe('re-exports tokens from a named token importer', () => {
 
 describe('omits importers whose specifier is a URL', () => {
   const source = dedent`
-      @import 'https://example.com/b.module.css';
-      @value c_1 from 'https://example.com/c.module.css';
-    `;
+    @import 'https://example.com/b.module.css';
+    @value c_1 from 'https://example.com/c.module.css';
+  `;
   test('default export', async () => {
     expect(await run(source, defaultExportOptions)).toMatchInlineSnapshot(`
     	"=== source ===
@@ -294,10 +294,10 @@ describe('omits importers whose specifier is a URL', () => {
 
 describe('omits tokens whose name fails validateTokenName', () => {
   const source = dedent`
-      .__proto__ { color: red; }
-      @value __proto__ from './b.module.css';
-      @value b_1 as __proto__ from './b.module.css';
-    `;
+    .__proto__ { color: red; }
+    @value __proto__ from './b.module.css';
+    @value b_1 as __proto__ from './b.module.css';
+  `;
   test('default export', async () => {
     expect(await run(source, defaultExportOptions)).toMatchInlineSnapshot(`
     	"=== source ===

--- a/packages/core/src/dts-generator.test.ts
+++ b/packages/core/src/dts-generator.test.ts
@@ -2,138 +2,358 @@ import dedent from 'dedent';
 import { describe, expect, test } from 'vite-plus/test';
 import { generateDts, type GenerateDtsOptions } from './dts-generator.js';
 import { readAndParseCSSModule } from './test/css-module.js';
+import { renderDtsResult } from './test/dts-mapping.js';
 import { createIFF } from './test/fixture.js';
 
-const options: GenerateDtsOptions = {
+const defaultExportOptions: GenerateDtsOptions = {
   namedExports: false,
   prioritizeNamedImports: false,
   forTsPlugin: false,
 };
 
-describe('generateDts', () => {
-  test('generates d.ts file if css module file has no tokens', async () => {
-    const iff = await createIFF({
-      'test.module.css': '',
-    });
-    expect(generateDts(readAndParseCSSModule(iff.paths['test.module.css'])!, options).text).toMatchInlineSnapshot(`
-      "// @ts-nocheck
-      declare const styles = {
-      };
-      export default styles;
-      "
+const namedExportOptions: GenerateDtsOptions = {
+  namedExports: true,
+  prioritizeNamedImports: false,
+  forTsPlugin: false,
+};
+
+async function run(source: string, options: GenerateDtsOptions): Promise<string> {
+  const iff = await createIFF({ 'a.module.css': source });
+  const cssModule = readAndParseCSSModule(iff.paths['a.module.css']);
+  if (cssModule === undefined) throw new Error('failed to parse CSS module');
+  return renderDtsResult(source, generateDts(cssModule, options));
+}
+
+describe('generates an empty .d.ts file when the CSS module has no tokens', () => {
+  test('default export', async () => {
+    expect(await run('', defaultExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+
+
+    	=== generated ===
+    	// @ts-nocheck
+    	declare const styles = {
+    	};
+    	export default styles;
+    	"
     `);
   });
-  test('generates d.ts file with local tokens', async () => {
-    const iff = await createIFF({
-      'test.module.css': dedent`
-        .local1 { color: red; }
-        .local2 { color: red; }
-      `,
-    });
-    expect(generateDts(readAndParseCSSModule(iff.paths['test.module.css'])!, options).text).toMatchInlineSnapshot(`
-      "// @ts-nocheck
-      declare const styles = {
-        'local1': '' as readonly string,
-        'local2': '' as readonly string,
-      };
-      export default styles;
-      "
+  test('named export', async () => {
+    expect(await run('', namedExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+
+
+    	=== generated ===
+    	// @ts-nocheck
+    	"
     `);
   });
-  test('generates types for token importers', async () => {
-    const iff = await createIFF({
-      'test.module.css': dedent`
-        @import './a.module.css';
-        @value imported1, imported2 as aliasedImported2 from './b.module.css';
-      `,
-    });
-    expect(generateDts(readAndParseCSSModule(iff.paths['test.module.css'])!, options).text).toMatchInlineSnapshot(`
-      "// @ts-nocheck
-      function blockErrorType<T>(val: T): [0] extends [(1 & T)] ? {} : T;
-      declare const styles = {
-        ...blockErrorType((await import('./a.module.css')).default),
-        'imported1': (await import('./b.module.css')).default['imported1'],
-        'aliasedImported2': (await import('./b.module.css')).default['imported2'],
-      };
-      export default styles;
-      "
+});
+
+describe('creates an entry for each local token declaration', () => {
+  const source = dedent`
+      .a_1 { color: red; }
+      .a_2 { color: red; }
+      .a_2 { color: red; }
+    `;
+  test('default export', async () => {
+    expect(await run(source, defaultExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+    	.a_1 { color: red; }
+    	 ^^^ mapping[0]
+    	.a_2 { color: red; }
+    	 ^^^ mapping[1]
+    	.a_2 { color: red; }
+    	 ^^^ mapping[2]
+
+    	=== generated ===
+    	// @ts-nocheck
+    	declare const styles = {
+    	  'a_1': '' as readonly string,
+    	   ^^^ mapping[0]
+    	  'a_2': '' as readonly string,
+    	   ^^^ mapping[1]
+    	  'a_2': '' as readonly string,
+    	   ^^^ mapping[2]
+    	};
+    	export default styles;
+    	"
     `);
   });
-  test('does not generate types for URL token importers', async () => {
-    const iff = await createIFF({
-      'test.module.css': dedent`
-        @import 'https://example.com/a.module.css';
-        @value imported1 from 'https://example.com/b.module.css';
-      `,
-    });
-    expect(generateDts(readAndParseCSSModule(iff.paths['test.module.css'])!, options).text).toMatchInlineSnapshot(`
-      "// @ts-nocheck
-      declare const styles = {
-      };
-      export default styles;
-      "
+  test('named export', async () => {
+    expect(await run(source, namedExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+    	.a_1 { color: red; }
+    	 ^^^ mapping[0]
+    	.a_2 { color: red; }
+    	 ^^^ mapping[1]
+    	.a_2 { color: red; }
+    	 ^^^ mapping[2]
+
+    	=== generated ===
+    	// @ts-nocheck
+    	var _token_0: string;
+    	    ^^^^^^^^ mapping[0]
+    	export { _token_0 as 'a_1' };
+    	                     ^^^^^ linkedCodeMapping[0]
+    	         ^^^^^^^^ linkedCodeMapping[0]
+    	var _token_1: string;
+    	    ^^^^^^^^ mapping[1]
+    	var _token_1: string;
+    	    ^^^^^^^^ mapping[2]
+    	export { _token_1 as 'a_2' };
+    	                     ^^^^^ linkedCodeMapping[1]
+    	         ^^^^^^^^ linkedCodeMapping[1]
+    	"
     `);
   });
-  test('does not generate types for invalid name', async () => {
-    const iff = await createIFF({
-      'test.module.css': dedent`
-        .__proto__ { color: red; }
-        @value __proto__ from './b.module.css';
-        @value b_1 as __proto__ from './b.module.css';
-      `,
-    });
-    expect(generateDts(readAndParseCSSModule(iff.paths['test.module.css'])!, options).text).toMatchInlineSnapshot(`
-      "// @ts-nocheck
-      declare const styles = {
-      };
-      export default styles;
-      "
+});
+
+describe('re-exports tokens from an all token importer', () => {
+  const source = dedent`
+    @import './b.module.css';
+    @import './c.module.css';
+    @import './c.module.css';
+  `;
+  test('default export', async () => {
+    expect(await run(source, defaultExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+    	@import './b.module.css';
+    	        ^^^^^^^^^^^^^^^^ mapping[0]
+    	@import './c.module.css';
+    	        ^^^^^^^^^^^^^^^^ mapping[1]
+    	@import './c.module.css';
+    	        ^^^^^^^^^^^^^^^^ mapping[2]
+
+    	=== generated ===
+    	// @ts-nocheck
+    	function blockErrorType<T>(val: T): [0] extends [(1 & T)] ? {} : T;
+    	declare const styles = {
+    	  ...blockErrorType((await import('./b.module.css')).default),
+    	                                  ^^^^^^^^^^^^^^^^ mapping[0]
+    	  ...blockErrorType((await import('./c.module.css')).default),
+    	                                  ^^^^^^^^^^^^^^^^ mapping[1]
+    	  ...blockErrorType((await import('./c.module.css')).default),
+    	                                  ^^^^^^^^^^^^^^^^ mapping[2]
+    	};
+    	export default styles;
+    	"
     `);
   });
-  test('generates d.ts file with named exports', async () => {
-    const iff = await createIFF({
-      'test.module.css': dedent`
-        .local1 { color: red; }
-        .local2 { color: red; }
-        .local2 { color: red; }
-        @import './a.module.css';
-        @value imported1, imported2 as aliasedImported2 from './b.module.css';
-      `,
-    });
-    expect(generateDts(readAndParseCSSModule(iff.paths['test.module.css'])!, { ...options, namedExports: true }).text)
+  test('named export', async () => {
+    expect(await run(source, namedExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+    	@import './b.module.css';
+    	        ^^^^^^^^^^^^^^^^ mapping[0]
+    	@import './c.module.css';
+    	        ^^^^^^^^^^^^^^^^ mapping[1]
+    	@import './c.module.css';
+    	        ^^^^^^^^^^^^^^^^ mapping[2]
+
+    	=== generated ===
+    	// @ts-nocheck
+    	export * from './b.module.css';
+    	              ^^^^^^^^^^^^^^^^ mapping[0]
+    	export * from './c.module.css';
+    	              ^^^^^^^^^^^^^^^^ mapping[1]
+    	export * from './c.module.css';
+    	              ^^^^^^^^^^^^^^^^ mapping[2]
+    	"
+    `);
+  });
+});
+
+describe('re-exports tokens from a named token importer', () => {
+  const source = dedent`
+    @value b_1, b_2 as b_alias from './b.module.css';
+    @value c_1 from './c.module.css';
+    @value c_1 from './c.module.css';
+  `;
+  test('default export', async () => {
+    expect(await run(source, defaultExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+    	@value b_1, b_2 as b_alias from './b.module.css';
+    	                                ^^^^^^^^^^^^^^^^ mapping[1]
+    	                   ^^^^^^^ mapping[2]
+    	            ^^^ mapping[3]
+    	       ^^^ mapping[0]
+    	@value c_1 from './c.module.css';
+    	                ^^^^^^^^^^^^^^^^ mapping[5]
+    	       ^^^ mapping[4]
+    	@value c_1 from './c.module.css';
+    	                ^^^^^^^^^^^^^^^^ mapping[7]
+    	       ^^^ mapping[6]
+
+    	=== generated ===
+    	// @ts-nocheck
+    	declare const styles = {
+    	  'b_1': (await import('./b.module.css')).default['b_1'],
+    	                                                  ^^^^^ linkedCodeMapping[0]
+    	                       ^^^^^^^^^^^^^^^^ mapping[1]
+    	   ^^^ mapping[0]
+    	  ^^^^^ linkedCodeMapping[0]
+    	  'b_alias': (await import('./b.module.css')).default['b_2'],
+    	                                                       ^^^ mapping[3]
+    	                                                      ^^^^^ linkedCodeMapping[1]
+    	   ^^^^^^^ mapping[2]
+    	  ^^^^^^^^^ linkedCodeMapping[1]
+    	  'c_1': (await import('./c.module.css')).default['c_1'],
+    	                                                  ^^^^^ linkedCodeMapping[2]
+    	                       ^^^^^^^^^^^^^^^^ mapping[5]
+    	   ^^^ mapping[4]
+    	  ^^^^^ linkedCodeMapping[2]
+    	  'c_1': (await import('./c.module.css')).default['c_1'],
+    	                                                  ^^^^^ linkedCodeMapping[3]
+    	                       ^^^^^^^^^^^^^^^^ mapping[7]
+    	   ^^^ mapping[6]
+    	  ^^^^^ linkedCodeMapping[3]
+    	};
+    	export default styles;
+    	"
+    `);
+  });
+  test('named export', async () => {
+    expect(await run(source, namedExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+    	@value b_1, b_2 as b_alias from './b.module.css';
+    	                                ^^^^^^^^^^^^^^^^ mapping[3]
+    	                   ^^^^^^^ mapping[2]
+    	            ^^^ mapping[1]
+    	       ^^^ mapping[0]
+    	@value c_1 from './c.module.css';
+    	                ^^^^^^^^^^^^^^^^ mapping[5]
+    	       ^^^ mapping[4]
+    	@value c_1 from './c.module.css';
+    	                ^^^^^^^^^^^^^^^^ mapping[7]
+    	       ^^^ mapping[6]
+
+    	=== generated ===
+    	// @ts-nocheck
+    	export {
+    	  'b_1' as 'b_1',
+    	            ^^^ mapping[0]
+    	           ^^^^^ linkedCodeMapping[0]
+    	  ^^^^^ linkedCodeMapping[0]
+    	  'b_2' as 'b_alias',
+    	            ^^^^^^^ mapping[2]
+    	           ^^^^^^^^^ linkedCodeMapping[1]
+    	   ^^^ mapping[1]
+    	  ^^^^^ linkedCodeMapping[1]
+    	} from './b.module.css';
+    	       ^^^^^^^^^^^^^^^^ mapping[3]
+    	export {
+    	  'c_1' as 'c_1',
+    	            ^^^ mapping[4]
+    	           ^^^^^ linkedCodeMapping[2]
+    	  ^^^^^ linkedCodeMapping[2]
+    	} from './c.module.css';
+    	       ^^^^^^^^^^^^^^^^ mapping[5]
+    	export {
+    	  'c_1' as 'c_1',
+    	            ^^^ mapping[6]
+    	           ^^^^^ linkedCodeMapping[3]
+    	  ^^^^^ linkedCodeMapping[3]
+    	} from './c.module.css';
+    	       ^^^^^^^^^^^^^^^^ mapping[7]
+    	"
+    `);
+  });
+});
+
+describe('omits importers whose specifier is a URL', () => {
+  const source = dedent`
+      @import 'https://example.com/b.module.css';
+      @value c_1 from 'https://example.com/c.module.css';
+    `;
+  test('default export', async () => {
+    expect(await run(source, defaultExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+    	@import 'https://example.com/b.module.css';
+    	@value c_1 from 'https://example.com/c.module.css';
+
+    	=== generated ===
+    	// @ts-nocheck
+    	declare const styles = {
+    	};
+    	export default styles;
+    	"
+    `);
+  });
+  test('named export', async () => {
+    expect(await run(source, namedExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+    	@import 'https://example.com/b.module.css';
+    	@value c_1 from 'https://example.com/c.module.css';
+
+    	=== generated ===
+    	// @ts-nocheck
+    	"
+    `);
+  });
+});
+
+describe('omits tokens whose name fails validateTokenName', () => {
+  const source = dedent`
+      .__proto__ { color: red; }
+      @value __proto__ from './b.module.css';
+      @value b_1 as __proto__ from './b.module.css';
+    `;
+  test('default export', async () => {
+    expect(await run(source, defaultExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+    	.__proto__ { color: red; }
+    	@value __proto__ from './b.module.css';
+    	@value b_1 as __proto__ from './b.module.css';
+
+    	=== generated ===
+    	// @ts-nocheck
+    	declare const styles = {
+    	};
+    	export default styles;
+    	"
+    `);
+  });
+  test('named export', async () => {
+    expect(await run(source, namedExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+    	.__proto__ { color: red; }
+    	@value __proto__ from './b.module.css';
+    	                      ^^^^^^^^^^^^^^^^ mapping[0]
+    	@value b_1 as __proto__ from './b.module.css';
+    	                             ^^^^^^^^^^^^^^^^ mapping[1]
+
+    	=== generated ===
+    	// @ts-nocheck
+    	export {
+    	} from './b.module.css';
+    	       ^^^^^^^^^^^^^^^^ mapping[0]
+    	export {
+    	} from './b.module.css';
+    	       ^^^^^^^^^^^^^^^^ mapping[1]
+    	"
+    `);
+  });
+});
+
+describe('keeps the default styles export so completion suggestions show up', () => {
+  test('named export with forTsPlugin and !prioritizeNamedImports', async () => {
+    const source = `.a_1 { color: red; }`;
+    expect(await run(source, { namedExports: true, prioritizeNamedImports: false, forTsPlugin: true }))
       .toMatchInlineSnapshot(`
-      	"// @ts-nocheck
+      	"=== source ===
+      	.a_1 { color: red; }
+      	 ^^^ mapping[0]
+
+      	=== generated ===
+      	// @ts-nocheck
       	var _token_0: string;
-      	export { _token_0 as 'local1' };
-      	var _token_1: string;
-      	var _token_1: string;
-      	export { _token_1 as 'local2' };
-      	export * from './a.module.css';
-      	export {
-      	  'imported1' as 'imported1',
-      	  'imported2' as 'aliasedImported2',
-      	} from './b.module.css';
+      	    ^^^^^^^^ mapping[0]
+      	export { _token_0 as 'a_1' };
+      	                     ^^^^^ linkedCodeMapping[0]
+      	         ^^^^^^^^ linkedCodeMapping[0]
+      	declare const styles: {};
+      	export default styles;
       	"
       `);
-  });
-  test('exports styles as default when `namedExports` and `forTsPlugin` are true, but `prioritizeNamedImports` is false', async () => {
-    const iff = await createIFF({
-      'test.module.css': '.local1 { color: red; }',
-    });
-    expect(
-      generateDts(readAndParseCSSModule(iff.paths['test.module.css'])!, {
-        ...options,
-        namedExports: true,
-        forTsPlugin: true,
-        prioritizeNamedImports: false,
-      }).text,
-    ).toMatchInlineSnapshot(`
-      "// @ts-nocheck
-      var _token_0: string;
-      export { _token_0 as 'local1' };
-      declare const styles: {};
-      export default styles;
-      "
-    `);
   });
 });

--- a/packages/core/src/dts-generator.test.ts
+++ b/packages/core/src/dts-generator.test.ts
@@ -335,25 +335,23 @@ describe('omits tokens whose name fails validateTokenName', () => {
   });
 });
 
-describe('keeps the default styles export so completion suggestions show up', () => {
-  test('named export with forTsPlugin and !prioritizeNamedImports', async () => {
-    const source = `.a_1 { color: red; }`;
-    expect(await run(source, { namedExports: true, prioritizeNamedImports: false, forTsPlugin: true }))
-      .toMatchInlineSnapshot(`
-      	"=== source ===
-      	.a_1 { color: red; }
-      	 ^^^ mapping[0]
+test('appends a default styles export so completion suggestions show up when forTsPlugin and namedExports are on without prioritizeNamedImports', async () => {
+  const source = `.a_1 { color: red; }`;
+  expect(await run(source, { namedExports: true, prioritizeNamedImports: false, forTsPlugin: true }))
+    .toMatchInlineSnapshot(`
+    	"=== source ===
+    	.a_1 { color: red; }
+    	 ^^^ mapping[0]
 
-      	=== generated ===
-      	// @ts-nocheck
-      	var _token_0: string;
-      	    ^^^^^^^^ mapping[0]
-      	export { _token_0 as 'a_1' };
-      	                     ^^^^^ linkedCodeMapping[0]
-      	         ^^^^^^^^ linkedCodeMapping[0]
-      	declare const styles: {};
-      	export default styles;
-      	"
-      `);
-  });
+    	=== generated ===
+    	// @ts-nocheck
+    	var _token_0: string;
+    	    ^^^^^^^^ mapping[0]
+    	export { _token_0 as 'a_1' };
+    	                     ^^^^^ linkedCodeMapping[0]
+    	         ^^^^^^^^ linkedCodeMapping[0]
+    	declare const styles: {};
+    	export default styles;
+    	"
+    `);
 });

--- a/packages/core/src/dts-generator.ts
+++ b/packages/core/src/dts-generator.ts
@@ -35,7 +35,7 @@ interface LinkedCodeMapping extends CodeMapping {
   generatedLengths: number[];
 }
 
-interface GenerateDtsResult {
+export interface GenerateDtsResult {
   text: string;
   mapping: CodeMapping;
   linkedCodeMapping: LinkedCodeMapping;

--- a/packages/core/src/test/dts-mapping.test.ts
+++ b/packages/core/src/test/dts-mapping.test.ts
@@ -1,0 +1,59 @@
+import dedent from 'dedent';
+import { expect, test } from 'vite-plus/test';
+import type { GenerateDtsResult } from '../dts-generator.js';
+import { renderDtsResult } from './dts-mapping.js';
+
+test('renderDtsResult', () => {
+  const source = dedent`
+    .a_1 {}
+    .a_2 .a_3 {}
+  `;
+  const dts = dedent`
+    var _token_0: string;
+    export { _token_0 as 'a_1' };
+    var _token_1: string;
+    export { _token_1 as 'a_2' };
+    var _token_2: string;
+    export { _token_2 as 'a_3' };
+  `;
+  const result: GenerateDtsResult = {
+    text: dts,
+    mapping: {
+      sourceOffsets: [source.indexOf('a_1'), source.indexOf('a_2'), source.indexOf('a_3')],
+      lengths: [3, 3, 3],
+      generatedOffsets: [dts.indexOf('_token_0'), dts.indexOf('_token_1'), dts.indexOf('_token_2')],
+      generatedLengths: [8, 8, 8],
+    },
+    linkedCodeMapping: {
+      sourceOffsets: [dts.indexOf('_token_0 as'), dts.indexOf('_token_1 as'), dts.indexOf('_token_2 as')],
+      lengths: [8, 8, 8],
+      generatedOffsets: [dts.indexOf("'a_1'"), dts.indexOf("'a_2'"), dts.indexOf("'a_3'")],
+      generatedLengths: [5, 5, 5],
+    },
+  };
+  expect(renderDtsResult(source, result)).toMatchInlineSnapshot(`
+  	"=== source ===
+  	.a_1 {}
+  	 ^^^ mapping[0]
+  	.a_2 .a_3 {}
+  	      ^^^ mapping[2]
+  	 ^^^ mapping[1]
+
+  	=== generated ===
+  	var _token_0: string;
+  	    ^^^^^^^^ mapping[0]
+  	export { _token_0 as 'a_1' };
+  	                     ^^^^^ linkedCodeMapping[0]
+  	         ^^^^^^^^ linkedCodeMapping[0]
+  	var _token_1: string;
+  	    ^^^^^^^^ mapping[1]
+  	export { _token_1 as 'a_2' };
+  	                     ^^^^^ linkedCodeMapping[1]
+  	         ^^^^^^^^ linkedCodeMapping[1]
+  	var _token_2: string;
+  	    ^^^^^^^^ mapping[2]
+  	export { _token_2 as 'a_3' };
+  	                     ^^^^^ linkedCodeMapping[2]
+  	         ^^^^^^^^ linkedCodeMapping[2]"
+  `);
+});

--- a/packages/core/src/test/dts-mapping.ts
+++ b/packages/core/src/test/dts-mapping.ts
@@ -1,0 +1,68 @@
+import type { GenerateDtsResult } from '../dts-generator.js';
+
+interface Marker {
+  name: string;
+  offset: number;
+  length: number;
+  index: number;
+}
+
+interface PositionedMarker extends Marker {
+  line: number;
+  column: number;
+}
+
+function renderMarkerLine(marker: PositionedMarker): string {
+  const indent = ' '.repeat(marker.column);
+  const carets = '^'.repeat(marker.length);
+  const label = `${marker.name}[${marker.index}]`;
+  return `${indent}${carets} ${label}`;
+}
+
+function offsetToPosition(text: string, offset: number): { line: number; column: number } {
+  let line = 1;
+  let lineStart = 0;
+  for (let i = 0; i < offset; i++) {
+    if (text[i] === '\n') {
+      line++;
+      lineStart = i + 1;
+    }
+  }
+  return { line, column: offset - lineStart };
+}
+
+function createMarkers(name: string, offsets: number[], lengths: number[]): Marker[] {
+  return offsets.map((offset, i) => ({ name, offset, length: lengths[i]!, index: i }));
+}
+
+function renderTextWithMarkers(text: string, markers: Marker[]): string {
+  const positioned: PositionedMarker[] = markers.map((m) => {
+    const { line, column } = offsetToPosition(text, m.offset);
+    return { ...m, line, column };
+  });
+
+  const markersByLine = Map.groupBy(positioned, (m) => m.line);
+
+  const result: string[] = [];
+  const lines = text.split('\n');
+  for (const [i, line] of lines.entries()) {
+    result.push(line);
+    const markers = (markersByLine.get(i + 1) ?? []).toSorted((a, b) => b.column - a.column);
+    for (const marker of markers) {
+      result.push(renderMarkerLine(marker));
+    }
+  }
+  return result.join('\n');
+}
+
+export function renderDtsResult(source: string, { text, mapping, linkedCodeMapping }: GenerateDtsResult): string {
+  const sourceMarkers = createMarkers('mapping', mapping.sourceOffsets, mapping.lengths);
+  const generatedMarkers = [
+    ...createMarkers('mapping', mapping.generatedOffsets, mapping.generatedLengths ?? mapping.lengths),
+    ...createMarkers('linkedCodeMapping', linkedCodeMapping.sourceOffsets, linkedCodeMapping.lengths),
+    ...createMarkers('linkedCodeMapping', linkedCodeMapping.generatedOffsets, linkedCodeMapping.generatedLengths),
+  ];
+  const renderedSource = renderTextWithMarkers(source, sourceMarkers);
+  const renderedGenerated = renderTextWithMarkers(text, generatedMarkers);
+  return `=== source ===\n${renderedSource}\n\n=== generated ===\n${renderedGenerated}`;
+}


### PR DESCRIPTION
## Motivation

The original `dts-generator.test.ts` had two gaps:

1. **Most behaviors were tested in only one export mode.** Empty CSS module, local tokens, URL-specifier exclusion, invalid token names, etc. were exercised in default-export mode only; named-export mode was covered by a single all-in-one test. Since `generateDefaultExportDts` and `generateNamedExportsDts` diverge significantly, this left the named-export side under-tested per behavior.

2. **`mapping` and `linkedCodeMapping` had no assertions.** Tests only inspected `result.text`, so off-by-one errors or missed entries in those arrays — which drive Go to Definition / Find All References / Rename via Volar.js in the ts-plugin — could silently break editor integration without any test failing.

## Approach

Two design choices stand out:

**1. Per-behavior, per-mode coverage.** Each behavior (e.g., "creates an entry for each local token declaration", "re-exports tokens from an all token importer") is structured as a `describe` containing one `default export` test and one `named export` test. The two cases run the same source CSS through `generateDts` with `namedExports: false` and `namedExports: true` respectively, so divergent code paths in `generateDefaultExportDts` and `generateNamedExportsDts` are exercised symmetrically.

**2. Visual mapping snapshots instead of `toStrictEqual`.** Asserting on `mapping` / `linkedCodeMapping` via `toStrictEqual({ sourceOffsets: [...], lengths: [...], ... })` is technically correct but humanly opaque — a reviewer cannot tell whether `sourceOffsets: [12, 18]` actually points to the right tokens without manually counting columns. The new `renderDtsResult` helper instead prints the source and the generated `.d.ts` as-is, then draws caret underlines below each line with labels like `mapping[0]` and `linkedCodeMapping[1]`. Reviewing a snapshot becomes a visual exercise: scan the carets, confirm they sit under the expected tokens.

Together these two choices keep the tests both **symmetric** (every behavior covered in both modes) and **legible** (mapping correctness is visible at a glance).

## Test plan
- [x] `vp test packages/core`
- [x] `vp check packages/core/src/test/dts-mapping.ts packages/core/src/test/dts-mapping.test.ts packages/core/src/dts-generator.test.ts packages/core/src/dts-generator.ts`
- [x] Visually reviewed each snapshot to confirm that the carets and labels point at the expected source/generated tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)