### PR TITLE
feat(core, ts-plugin, eslint-plugin, stylelint-plugin): support animation-name property

### DIFF
--- a/.changeset/keyframes-references.md
+++ b/.changeset/keyframes-references.md
@@ -1,0 +1,17 @@
+---
+'@css-modules-kit/core': minor
+'@css-modules-kit/ts-plugin': minor
+'@css-modules-kit/eslint-plugin': patch
+'@css-modules-kit/stylelint-plugin': patch
+---
+
+feat(core, ts-plugin, eslint-plugin, stylelint-plugin): support animation-name property
+
+`animation-name: foo;` is now linked back to the `@keyframes foo {...}` declaration. Go to Definition jumps from a reference to the declaration, Find All References lists every reference site, and Rename updates the declaration and every reference together. Comma-separated names (`animation-name: foo, bar;`), `local()` / `global()` notation, and vendor prefixes (`-webkit-animation-name`) are all supported. References to `@keyframes` defined in another file via `@import` are resolved as well.
+
+Two diagnostics are also emitted for invalid usage:
+
+- Parse phase: malformed `local(...)` calls (empty, multiple identifiers, or non-identifier nodes such as a nested function) are reported.
+- Check phase: token references that resolve to neither a locally defined token nor an imported token are reported as `Cannot find token '<name>'.`.
+
+The `no-unused-class-names` rule in eslint-plugin and stylelint-plugin now treats names referenced via `animation-name` from within the same CSS as used, so they are no longer reported as unused.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,8 @@ function myFunction() {
 
 ## Glossary
 
-- **Token**: A generic term for things exported by CSS Modules, such as class names and values defined with `@value`.
+- **Token**: A generic term for things exported by CSS Modules, such as class names, `@value` definitions, and `@keyframes` names.
+- **Token reference**: A usage of a token elsewhere in the CSS. Currently produced for `animation-name: <name>`. The referenced token may be defined in the same file (e.g. `@keyframes`) or imported via `@import` / `@value ... from`.
 - **Diagnostic**: An object representing errors or warnings
 - **Parse phase**: The phase that parses CSS Modules files and extracts token information
 - **Check phase**: The phase that validates CSS Modules files

--- a/docs/ts-plugin-internals.ja.md
+++ b/docs/ts-plugin-internals.ja.md
@@ -301,3 +301,42 @@ CSS Modules Kit ではこの問題を、
 これにより `getDefinitionAtPosition` の `{ start: 27, length: 5 }` も、内側の `{ start: 28, length: 3 }` で再試行することで mapping にマッチするようになります。
 
 参考: [mizdra/volar-single-quote-span-problem](https://github.com/mizdra/volar-single-quote-span-problem)
+
+### Token References (`animation-name`) のサポート
+
+CSS では `@keyframes foo {...}` で定義したアニメーション名を `animation-name: foo;` で参照できます。CSS Modules Kit はこの参照を Volar.js の mapping を介して定義側と結びつけ、Go to Definition / Find All References / Rename を一貫して動作させます。
+
+仕組みとしては、生成する `.d.ts` の末尾に「参照の式」を埋め込みます。default export の場合は `styles['<name>'];` という bracket access の式文として、named export の場合は自モジュールへの self-import (`declare const __self: typeof import('./<self-basename>');`) を 1 度生成した上で `__self['<name>'];` という bracket access として吐きます。各参照式のクオート内側部分には CSS 側の参照位置の mapping を張ります。
+
+例えば、次のような CSS モジュールがあるとします:
+
+`src/a.module.css`:
+
+```css
+@keyframes a_1 {}
+.a_2 { animation-name: a_1; }
+```
+
+default export の場合、次のような型定義が生成されます:
+
+```ts
+declare const styles = {
+  'a_1': '' as readonly string,
+  'a_2': '' as readonly string,
+};
+styles['a_1'];
+export default styles;
+```
+
+このようにすることで、`animation-name: a_1;` の `a_1` に対して Go to Definition をした時に、`.d.ts` 上の `styles['a_1']` から CSS 上の `@keyframes a_1` へとジャンプできるようになります。また、`@keyframes a_1 {}` の `a_1` に対して Find All References をした時に、`@keyframes a_1` と `animation-name: a_1;` の両方が返されるようになります。
+
+ちなみに named export の場合、次のような型定義が生成されます:
+
+```ts
+var _token_0: string;
+export { _token_0 as 'a_1' };
+var _token_1: string;
+export { _token_1 as 'a_2' };
+declare const __self: typeof import('./a.module.css');
+__self['a_1'];
+```

--- a/docs/ts-plugin-internals.md
+++ b/docs/ts-plugin-internals.md
@@ -304,3 +304,42 @@ The fallback is implemented in `CustomSourceMap` in [packages/ts-plugin/src/sour
 With this, `getDefinitionAtPosition`'s `{ start: 27, length: 5 }` also matches the mapping by retrying with the inner `{ start: 28, length: 3 }`.
 
 Reference: [mizdra/volar-single-quote-span-problem](https://github.com/mizdra/volar-single-quote-span-problem)
+
+### Token References (`animation-name`) Support
+
+In CSS, an animation name defined with `@keyframes foo {...}` can be referenced by `animation-name: foo;`. CSS Modules Kit links such references to their definitions via Volar.js mappings, making Go to Definition / Find All References / Rename work consistently.
+
+The mechanism is to embed "reference expressions" at the end of the generated `.d.ts`. For default export, it is emitted as a bracket access expression statement like `styles['<name>'];`. For named export, after emitting a self-import (`declare const __self: typeof import('./<self-basename>');`) once, it is emitted as a bracket access like `__self['<name>'];`. A mapping is attached to the inside-of-quotes part of each reference expression, pointing to the reference position in the CSS.
+
+For example, suppose we have the following CSS module:
+
+`src/a.module.css`:
+
+```css
+@keyframes a_1 {}
+.a_2 { animation-name: a_1; }
+```
+
+For default export, the following type definition is generated:
+
+```ts
+declare const styles = {
+  'a_1': '' as readonly string,
+  'a_2': '' as readonly string,
+};
+styles['a_1'];
+export default styles;
+```
+
+With this, when Go to Definition is invoked on `a_1` in `animation-name: a_1;`, it can jump from `styles['a_1']` in the `.d.ts` to `@keyframes a_1` in the CSS. Similarly, when Find All References is invoked on `a_1` in `@keyframes a_1 {}`, both `@keyframes a_1` and `animation-name: a_1;` are returned.
+
+For named export, the following type definition is generated:
+
+```ts
+var _token_0: string;
+export { _token_0 as 'a_1' };
+var _token_1: string;
+export { _token_1 as 'a_2' };
+declare const __self: typeof import('./a.module.css');
+__self['a_1'];
+```

--- a/examples/1-basic/generated/src/a.module.css.d.ts
+++ b/examples/1-basic/generated/src/a.module.css.d.ts
@@ -6,8 +6,10 @@ declare const styles = {
   'a_2': '' as readonly string,
   'a_3': '' as readonly string,
   'a_4': '' as readonly string,
+  'a_5': '' as readonly string,
   ...blockErrorType((await import('./b.module.css')).default),
   'c_1': (await import('./c.module.css')).default['c_1'],
   'c_alias': (await import('./c.module.css')).default['c_2'],
 };
+styles['a_4'];
 export default styles;

--- a/examples/1-basic/src/a.module.css
+++ b/examples/1-basic/src/a.module.css
@@ -6,6 +6,9 @@
   0% { transform: translateY(0); }
   100% { transform: translateY(-100%); }
 }
+.a_5 {
+  animation-name: a_4;
+}
 
 @import './b.module.css';
 @value c_1, c_2 as c_alias from './c.module.css';

--- a/examples/1-basic/src/a.tsx
+++ b/examples/1-basic/src/a.tsx
@@ -4,6 +4,7 @@ styles.a_1;
 styles.a_2;
 styles.a_3;
 styles.a_4;
+styles.a_5;
 styles.b_1;
 styles.b_2;
 styles.c_1;

--- a/packages/core/src/checker.test.ts
+++ b/packages/core/src/checker.test.ts
@@ -264,4 +264,40 @@ describe('checkCSSModule', () => {
     // TODO: Report diagnostics
     expect(diagnostics).toEqual([]);
   });
+  test('report diagnostics for references to undefined tokens', async () => {
+    const iff = await createIFF({
+      'a.module.css': dedent`
+        @keyframes a_1 {}
+        .a_2 { animation-name: a_1, a_3; }
+      `,
+    });
+    const check = prepareChecker();
+    const diagnostics = check(readAndParseCSSModule(iff.paths['a.module.css'])!);
+    expect(formatDiagnostics(diagnostics, iff.rootDir)).toMatchInlineSnapshot(`
+    	[
+    	  {
+    	    "category": "error",
+    	    "fileName": "<rootDir>/a.module.css",
+    	    "length": 3,
+    	    "start": {
+    	      "column": 29,
+    	      "line": 2,
+    	    },
+    	    "text": "Cannot find token 'a_3'.",
+    	  },
+    	]
+    `);
+  });
+  test('do not report diagnostics for references to tokens imported via @import', async () => {
+    const iff = await createIFF({
+      'a.module.css': dedent`
+        @import './b.module.css';
+        .a_1 { animation-name: b_1; }
+      `,
+      'b.module.css': '@keyframes b_1 {}',
+    });
+    const check = prepareChecker();
+    const diagnostics = check(readAndParseCSSModule(iff.paths['a.module.css'])!);
+    expect(diagnostics).toEqual([]);
+  });
 });

--- a/packages/core/src/checker.ts
+++ b/packages/core/src/checker.ts
@@ -9,6 +9,7 @@ import type {
   NamedTokenImporterEntry,
   Resolver,
   TokenImporter,
+  TokenReference,
 } from './type.js';
 import { isURLSpecifier, type TokenNameViolation, validateTokenName } from './util.js';
 
@@ -62,6 +63,13 @@ export function checkCSSModule(cssModule: CSSModule, args: CheckerArgs): Diagnos
       }
     }
   }
+
+  const exportRecord = args.getExportRecord(cssModule);
+  for (const reference of cssModule.tokenReferences) {
+    if (!exportRecord.allTokens.includes(reference.name)) {
+      diagnostics.push(createTokenNotFoundDiagnostic(cssModule, reference));
+    }
+  }
   return diagnostics;
 }
 
@@ -110,5 +118,15 @@ function createModuleHasNoExportedTokenDiagnostic(
     file: { fileName: cssModule.fileName, text: cssModule.text },
     start: { line: entry.loc.start.line, column: entry.loc.start.column },
     length: entry.loc.end.offset - entry.loc.start.offset,
+  };
+}
+
+function createTokenNotFoundDiagnostic(cssModule: CSSModule, reference: TokenReference): Diagnostic {
+  return {
+    text: `Cannot find token '${reference.name}'.`,
+    category: 'error',
+    file: { fileName: cssModule.fileName, text: cssModule.text },
+    start: { line: reference.loc.start.line, column: reference.loc.start.column },
+    length: reference.loc.end.offset - reference.loc.start.offset,
   };
 }

--- a/packages/core/src/dts-generator.test.ts
+++ b/packages/core/src/dts-generator.test.ts
@@ -261,6 +261,63 @@ describe('re-exports tokens from a named token importer', () => {
   });
 });
 
+describe('creates a reference for a token reference', () => {
+  const source = dedent`
+    @keyframes a_1 {}
+    .a_2 { animation-name: a_1; }
+  `;
+  test('default export', async () => {
+    expect(await run(source, defaultExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+    	@keyframes a_1 {}
+    	           ^^^ mapping[0]
+    	.a_2 { animation-name: a_1; }
+    	                       ^^^ mapping[2]
+    	 ^^^ mapping[1]
+
+    	=== generated ===
+    	// @ts-nocheck
+    	declare const styles = {
+    	  'a_1': '' as readonly string,
+    	   ^^^ mapping[0]
+    	  'a_2': '' as readonly string,
+    	   ^^^ mapping[1]
+    	};
+    	styles['a_1'];
+    	        ^^^ mapping[2]
+    	export default styles;
+    	"
+    `);
+  });
+  test('named export', async () => {
+    expect(await run(source, namedExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+    	@keyframes a_1 {}
+    	           ^^^ mapping[0]
+    	.a_2 { animation-name: a_1; }
+    	                       ^^^ mapping[2]
+    	 ^^^ mapping[1]
+
+    	=== generated ===
+    	// @ts-nocheck
+    	var _token_0: string;
+    	    ^^^^^^^^ mapping[0]
+    	export { _token_0 as 'a_1' };
+    	                     ^^^^^ linkedCodeMapping[0]
+    	         ^^^^^^^^ linkedCodeMapping[0]
+    	var _token_1: string;
+    	    ^^^^^^^^ mapping[1]
+    	export { _token_1 as 'a_2' };
+    	                     ^^^^^ linkedCodeMapping[1]
+    	         ^^^^^^^^ linkedCodeMapping[1]
+    	declare const __self: typeof import('./a.module.css');
+    	__self['a_1'];
+    	        ^^^ mapping[2]
+    	"
+    `);
+  });
+});
+
 describe('omits importers whose specifier is a URL', () => {
   const source = dedent`
     @import 'https://example.com/b.module.css';

--- a/packages/core/src/dts-generator.ts
+++ b/packages/core/src/dts-generator.ts
@@ -1,4 +1,5 @@
-import type { CSSModule, Token, TokenImporter } from './type.js';
+import { basename } from './path.js';
+import type { CSSModule, Token, TokenImporter, TokenReference } from './type.js';
 import type { ValidateTokenNameOptions } from './util.js';
 import { isURLSpecifier, validateTokenName } from './util.js';
 
@@ -47,6 +48,7 @@ export interface GenerateDtsResult {
 export function generateDts(cssModule: CSSModule, options: GenerateDtsOptions): GenerateDtsResult {
   // Exclude invalid tokens
   const localTokens = cssModule.localTokens.filter((token) => isValidTokenName(token.name, options));
+  const tokenReferences = cssModule.tokenReferences.filter((ref) => isValidTokenName(ref.name, options));
   const tokenImporters = cssModule.tokenImporters
     // Exclude invalid imported tokens
     .map((tokenImporter) => {
@@ -103,16 +105,18 @@ export function generateDts(cssModule: CSSModule, options: GenerateDtsOptions): 
     });
 
   if (options.namedExports) {
-    return generateNamedExportsDts(localTokens, tokenImporters, options);
+    return generateNamedExportsDts(cssModule.fileName, localTokens, tokenImporters, tokenReferences, options);
   } else {
-    return generateDefaultExportDts(localTokens, tokenImporters);
+    return generateDefaultExportDts(localTokens, tokenImporters, tokenReferences);
   }
 }
 
 /** Generate a d.ts file with named exports. */
 function generateNamedExportsDts(
+  fileName: string,
   localTokens: Token[],
   tokenImporters: TokenImporter[],
+  tokenReferences: TokenReference[],
   options: GenerateDtsOptions,
 ): { text: string; mapping: CodeMapping; linkedCodeMapping: LinkedCodeMapping } {
   const mapping: Required<CodeMapping> = {
@@ -276,6 +280,30 @@ function generateNamedExportsDts(
   if (noModuleSyntax) {
     text += 'export {};\n';
   }
+
+  /**
+   * The mapping is created as follows:
+   * a.module.css:
+   * 1 | @keyframes a_1 { ... }
+   * 2 | .a_2 { animation-name: a_1; }
+   *   |                        ^ mapping.sourceOffsets[0]
+   *
+   * a.module.css.d.ts:
+   * 1 | declare const __self: typeof import('./<self-filename>');
+   * 2 | __self['a_1'];
+   *   |             ^ mapping.generatedOffsets[0]
+   */
+  if (tokenReferences.length > 0) {
+    text += `declare const __self: typeof import('./${basename(fileName)}');\n`;
+    for (const ref of tokenReferences) {
+      text += `__self['`;
+      mapping.sourceOffsets.push(ref.loc.start.offset);
+      mapping.lengths.push(ref.name.length);
+      mapping.generatedOffsets.push(text.length);
+      mapping.generatedLengths.push(ref.name.length);
+      text += `${ref.name}'];\n`;
+    }
+  }
   if (options.forTsPlugin && !options.prioritizeNamedImports) {
     // Export `styles` to appear in code completion suggestions
     text += 'declare const styles: {};\nexport default styles;\n';
@@ -287,6 +315,7 @@ function generateNamedExportsDts(
 function generateDefaultExportDts(
   localTokens: Token[],
   tokenImporters: TokenImporter[],
+  tokenReferences: TokenReference[],
 ): {
   text: string;
   mapping: CodeMapping;
@@ -444,7 +473,27 @@ function generateDefaultExportDts(
       });
     }
   }
-  text += `};\nexport default ${STYLES_EXPORT_NAME};\n`;
+  text += `};\n`;
+
+  /**
+   * The mapping is created as follows:
+   * a.module.css:
+   * 1 | @keyframes a_1 { ... }
+   * 2 | .a_2 { animation-name: a_1; }
+   *   |                        ^ mapping.sourceOffsets[0]
+   *
+   * a.module.css.d.ts:
+   * 1 | styles['a_1'];
+   *   |         ^ mapping.generatedOffsets[0]
+   */
+  for (const ref of tokenReferences) {
+    text += `${STYLES_EXPORT_NAME}['`;
+    mapping.sourceOffsets.push(ref.loc.start.offset);
+    mapping.lengths.push(ref.name.length);
+    mapping.generatedOffsets.push(text.length);
+    text += `${ref.name}'];\n`;
+  }
+  text += `export default ${STYLES_EXPORT_NAME};\n`;
   return { text, mapping, linkedCodeMapping };
 }
 

--- a/packages/core/src/parser/animation-parser.test.ts
+++ b/packages/core/src/parser/animation-parser.test.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent';
 import { describe, expect, test } from 'vite-plus/test';
 import { fakeDeclaration } from '../test/ast.js';
 import { isAnimationNameProp, parseAnimationNameProp } from './animation-parser.js';
@@ -201,6 +202,64 @@ describe('parseAnimationNameProp', () => {
     	    },
     	  ],
     	  "references": [],
+    	}
+    `);
+  });
+
+  test('handles references on lines after the declaration start', () => {
+    const decl = fakeDeclaration(dedent`
+      .a_1 {
+        animation-name:
+          a_2,
+          local(a_3),
+          local(a_4 a_5);
+      }
+    `);
+    expect(parseAnimationNameProp(decl)).toMatchInlineSnapshot(`
+    	{
+    	  "diagnostics": [
+    	    {
+    	      "category": "error",
+    	      "length": 14,
+    	      "start": {
+    	        "column": 5,
+    	        "line": 5,
+    	      },
+    	      "text": "\`local(...)\` must contain exactly one identifier.",
+    	    },
+    	  ],
+    	  "references": [
+    	    {
+    	      "loc": {
+    	        "end": {
+    	          "column": 8,
+    	          "line": 3,
+    	          "offset": 32,
+    	        },
+    	        "start": {
+    	          "column": 5,
+    	          "line": 3,
+    	          "offset": 29,
+    	        },
+    	      },
+    	      "name": "a_2",
+    	    },
+    	    {
+    	      "loc": {
+    	        "end": {
+    	          "column": 14,
+    	          "line": 4,
+    	          "offset": 47,
+    	        },
+    	        "start": {
+    	          "column": 11,
+    	          "line": 4,
+    	          "offset": 44,
+    	        },
+    	      },
+    	      "name": "a_3",
+    	    },
+    	  ],
     	}
     `);
   });

--- a/packages/core/src/parser/animation-parser.test.ts
+++ b/packages/core/src/parser/animation-parser.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from 'vite-plus/test';
+import { fakeDeclaration } from '../test/ast.js';
+import { isAnimationNameProp, parseAnimationNameProp } from './animation-parser.js';
+
+describe('isAnimationNameProp', () => {
+  test.each([
+    ['animation-name', true],
+    ['-webkit-animation-name', true],
+    ['-moz-animation-name', true],
+    ['-o-animation-name', true],
+    ['-ms-animation-name', true],
+    ['Animation-Name', true],
+    ['animation', false],
+    ['color', false],
+  ])('%s -> %s', (prop, expected) => {
+    expect(isAnimationNameProp(prop)).toBe(expected);
+  });
+});
+
+describe('parseAnimationNameProp', () => {
+  test('extracts a single ident', () => {
+    const decl = fakeDeclaration('.a_1 { animation-name: a_2 }');
+    expect(parseAnimationNameProp(decl)).toMatchInlineSnapshot(`
+    	{
+    	  "diagnostics": [],
+    	  "references": [
+    	    {
+    	      "loc": {
+    	        "end": {
+    	          "column": 27,
+    	          "line": 1,
+    	          "offset": 26,
+    	        },
+    	        "start": {
+    	          "column": 24,
+    	          "line": 1,
+    	          "offset": 23,
+    	        },
+    	      },
+    	      "name": "a_2",
+    	    },
+    	  ],
+    	}
+    `);
+  });
+
+  test('extracts comma-separated idents', () => {
+    const decl = fakeDeclaration('.a_1 { animation-name: a_2, a_3 }');
+    expect(parseAnimationNameProp(decl)).toMatchInlineSnapshot(`
+    	{
+    	  "diagnostics": [],
+    	  "references": [
+    	    {
+    	      "loc": {
+    	        "end": {
+    	          "column": 27,
+    	          "line": 1,
+    	          "offset": 26,
+    	        },
+    	        "start": {
+    	          "column": 24,
+    	          "line": 1,
+    	          "offset": 23,
+    	        },
+    	      },
+    	      "name": "a_2",
+    	    },
+    	    {
+    	      "loc": {
+    	        "end": {
+    	          "column": 32,
+    	          "line": 1,
+    	          "offset": 31,
+    	        },
+    	        "start": {
+    	          "column": 29,
+    	          "line": 1,
+    	          "offset": 28,
+    	        },
+    	      },
+    	      "name": "a_3",
+    	    },
+    	  ],
+    	}
+    `);
+  });
+
+  test('extracts ident from local()', () => {
+    const decl = fakeDeclaration('.a_1 { animation-name: local(a_2) }');
+    expect(parseAnimationNameProp(decl)).toMatchInlineSnapshot(`
+    	{
+    	  "diagnostics": [],
+    	  "references": [
+    	    {
+    	      "loc": {
+    	        "end": {
+    	          "column": 33,
+    	          "line": 1,
+    	          "offset": 32,
+    	        },
+    	        "start": {
+    	          "column": 30,
+    	          "line": 1,
+    	          "offset": 29,
+    	        },
+    	      },
+    	      "name": "a_2",
+    	    },
+    	  ],
+    	}
+    `);
+  });
+
+  test('skips ident inside global()', () => {
+    const decl = fakeDeclaration('.a_1 { animation-name: global(a_2) }');
+    expect(parseAnimationNameProp(decl)).toMatchInlineSnapshot(`
+    	{
+    	  "diagnostics": [],
+    	  "references": [],
+    	}
+    `);
+  });
+
+  test('skips ident inside var()', () => {
+    const decl = fakeDeclaration('.a_1 { animation-name: var(--a_2) }');
+    expect(parseAnimationNameProp(decl)).toMatchInlineSnapshot(`
+    	{
+    	  "diagnostics": [],
+    	  "references": [],
+    	}
+    `);
+  });
+
+  test('skips ident inside env()', () => {
+    const decl = fakeDeclaration('.a_1 { animation-name: env(a_2) }');
+    expect(parseAnimationNameProp(decl)).toMatchInlineSnapshot(`
+    	{
+    	  "diagnostics": [],
+    	  "references": [],
+    	}
+    `);
+  });
+
+  test('skips reserved keywords (none, revert, revert-layer)', () => {
+    const decl = fakeDeclaration('.a_1 { animation-name: revert, a_2, none }');
+    expect(parseAnimationNameProp(decl)).toMatchInlineSnapshot(`
+    	{
+    	  "diagnostics": [],
+    	  "references": [
+    	    {
+    	      "loc": {
+    	        "end": {
+    	          "column": 35,
+    	          "line": 1,
+    	          "offset": 34,
+    	        },
+    	        "start": {
+    	          "column": 32,
+    	          "line": 1,
+    	          "offset": 31,
+    	        },
+    	      },
+    	      "name": "a_2",
+    	    },
+    	  ],
+    	}
+    `);
+  });
+
+  test('reports a diagnostic and skips references for invalid local() shapes (multiple idents, non-identifier node, empty)', () => {
+    const decl = fakeDeclaration('.a_1 { animation-name: local(a_2, a_3), local(a_4, local(a_5)), local() }');
+    expect(parseAnimationNameProp(decl)).toMatchInlineSnapshot(`
+    	{
+    	  "diagnostics": [
+    	    {
+    	      "category": "error",
+    	      "length": 15,
+    	      "start": {
+    	        "column": 24,
+    	        "line": 1,
+    	      },
+    	      "text": "\`local(...)\` must contain exactly one identifier.",
+    	    },
+    	    {
+    	      "category": "error",
+    	      "length": 22,
+    	      "start": {
+    	        "column": 41,
+    	        "line": 1,
+    	      },
+    	      "text": "\`local(...)\` must contain exactly one identifier.",
+    	    },
+    	    {
+    	      "category": "error",
+    	      "length": 7,
+    	      "start": {
+    	        "column": 65,
+    	        "line": 1,
+    	      },
+    	      "text": "\`local(...)\` must contain exactly one identifier.",
+    	    },
+    	  ],
+    	  "references": [],
+    	}
+    `);
+  });
+});

--- a/packages/core/src/parser/animation-parser.ts
+++ b/packages/core/src/parser/animation-parser.ts
@@ -53,13 +53,10 @@ function unwrapLocalCall(fn: postcssValueParser.FunctionNode): postcssValueParse
 
 function calcLoc(decl: Declaration, animationNameNode: postcssValueParser.WordNode): Location {
   const baseLength = decl.prop.length + decl.raws.between!.length;
-  const start = decl.source!.start!;
-  const startOffset = start.offset + baseLength + animationNameNode.sourceIndex;
-  const startColumn = start.column + baseLength + animationNameNode.sourceIndex;
-  const length = animationNameNode.value.length;
+  const startIndex = baseLength + animationNameNode.sourceIndex;
   return {
-    start: { line: start.line, column: startColumn, offset: startOffset },
-    end: { line: start.line, column: startColumn + length, offset: startOffset + length },
+    start: decl.positionBy({ index: startIndex }),
+    end: decl.positionBy({ index: startIndex + animationNameNode.value.length }),
   };
 }
 
@@ -68,15 +65,11 @@ function createInvalidLocalCallDiagnostic(
   fn: postcssValueParser.FunctionNode,
 ): DiagnosticWithDetachedLocation {
   const baseLength = decl.prop.length + decl.raws.between!.length;
-  const start = decl.source!.start!;
-  const length = postcssValueParser.stringify(fn).length;
+  const start = decl.positionBy({ index: baseLength + fn.sourceIndex });
   return {
     text: '`local(...)` must contain exactly one identifier.',
     category: 'error',
-    start: {
-      line: start.line,
-      column: start.column + baseLength + fn.sourceIndex,
-    },
-    length,
+    start: { line: start.line, column: start.column },
+    length: postcssValueParser.stringify(fn).length,
   };
 }

--- a/packages/core/src/parser/animation-parser.ts
+++ b/packages/core/src/parser/animation-parser.ts
@@ -1,0 +1,82 @@
+import type { Declaration } from 'postcss';
+import postcssValueParser from 'postcss-value-parser';
+import type { DiagnosticWithDetachedLocation, Location, TokenReference } from '../type.js';
+
+const ANIMATION_NAME_PROP_RE = /^(?:-(?:webkit|moz|o|ms)-)?animation-name$/iu;
+
+export function isAnimationNameProp(prop: string): boolean {
+  return ANIMATION_NAME_PROP_RE.test(prop);
+}
+
+const COMMON_RESERVED_KEYWORDS = new Set(['none', 'inherit', 'initial', 'unset', 'revert', 'revert-layer']);
+
+interface ParseAnimationResult {
+  references: TokenReference[];
+  diagnostics: DiagnosticWithDetachedLocation[];
+}
+
+/** Parse an `animation-name` declaration and extract token references. */
+export function parseAnimationNameProp(decl: Declaration): ParseAnimationResult {
+  const references: TokenReference[] = [];
+  const diagnostics: DiagnosticWithDetachedLocation[] = [];
+  const parsed = postcssValueParser(decl.value);
+  for (const node of parsed.nodes) {
+    if (node.type === 'function') {
+      // `global(name)`, `var(...)`, `env(...)`, and any other function are skipped.
+      if (node.value !== 'local') continue;
+      const nameNodeOrError = unwrapLocalCall(node);
+      if (nameNodeOrError === 'invalid') {
+        diagnostics.push(createInvalidLocalCallDiagnostic(decl, node));
+        continue;
+      }
+      references.push({ name: nameNodeOrError.value, loc: calcLoc(decl, nameNodeOrError) });
+      continue;
+    }
+    if (node.type !== 'word') continue;
+    if (COMMON_RESERVED_KEYWORDS.has(node.value.toLowerCase())) continue;
+    references.push({ name: node.value, loc: calcLoc(decl, node) });
+  }
+  return { references, diagnostics };
+}
+
+/**
+ * Inspect a `local(...)` call and return its single identifier, or `'invalid'`
+ * for any other shape (empty, multiple words, nested functions, strings, etc.).
+ */
+function unwrapLocalCall(fn: postcssValueParser.FunctionNode): postcssValueParser.WordNode | 'invalid' {
+  const words = fn.nodes.filter((n) => n.type !== 'space');
+  if (words.length === 1 && words[0]!.type === 'word') {
+    return words[0]!;
+  }
+  return 'invalid';
+}
+
+function calcLoc(decl: Declaration, animationNameNode: postcssValueParser.WordNode): Location {
+  const baseLength = decl.prop.length + decl.raws.between!.length;
+  const start = decl.source!.start!;
+  const startOffset = start.offset + baseLength + animationNameNode.sourceIndex;
+  const startColumn = start.column + baseLength + animationNameNode.sourceIndex;
+  const length = animationNameNode.value.length;
+  return {
+    start: { line: start.line, column: startColumn, offset: startOffset },
+    end: { line: start.line, column: startColumn + length, offset: startOffset + length },
+  };
+}
+
+function createInvalidLocalCallDiagnostic(
+  decl: Declaration,
+  fn: postcssValueParser.FunctionNode,
+): DiagnosticWithDetachedLocation {
+  const baseLength = decl.prop.length + decl.raws.between!.length;
+  const start = decl.source!.start!;
+  const length = postcssValueParser.stringify(fn).length;
+  return {
+    text: '`local(...)` must contain exactly one identifier.',
+    category: 'error',
+    start: {
+      line: start.line,
+      column: start.column + baseLength + fn.sourceIndex,
+    },
+    length,
+  };
+}

--- a/packages/core/src/parser/css-module-parser.test.ts
+++ b/packages/core/src/parser/css-module-parser.test.ts
@@ -29,462 +29,463 @@ describe('parseCSSModule', () => {
       options,
     );
     expect(parsed).toMatchInlineSnapshot(`
-      {
-        "diagnostics": [],
-        "fileName": "/test.module.css",
-        "localTokens": [
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 10,
-                "line": 1,
-                "offset": 9,
-              },
-              "start": {
-                "column": 1,
-                "line": 1,
-                "offset": 0,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 7,
-                "line": 1,
-                "offset": 6,
-              },
-              "start": {
-                "column": 2,
-                "line": 1,
-                "offset": 1,
-              },
-            },
-            "name": "basic",
-          },
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 14,
-                "line": 2,
-                "offset": 23,
-              },
-              "start": {
-                "column": 1,
-                "line": 2,
-                "offset": 10,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 11,
-                "line": 2,
-                "offset": 20,
-              },
-              "start": {
-                "column": 2,
-                "line": 2,
-                "offset": 11,
-              },
-            },
-            "name": "cascading",
-          },
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 14,
-                "line": 3,
-                "offset": 37,
-              },
-              "start": {
-                "column": 1,
-                "line": 3,
-                "offset": 24,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 11,
-                "line": 3,
-                "offset": 34,
-              },
-              "start": {
-                "column": 2,
-                "line": 3,
-                "offset": 25,
-              },
-            },
-            "name": "cascading",
-          },
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 19,
-                "line": 4,
-                "offset": 56,
-              },
-              "start": {
-                "column": 1,
-                "line": 4,
-                "offset": 38,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 16,
-                "line": 4,
-                "offset": 53,
-              },
-              "start": {
-                "column": 2,
-                "line": 4,
-                "offset": 39,
-              },
-            },
-            "name": "pseudo_class_1",
-          },
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 25,
-                "line": 5,
-                "offset": 81,
-              },
-              "start": {
-                "column": 1,
-                "line": 5,
-                "offset": 57,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 16,
-                "line": 5,
-                "offset": 72,
-              },
-              "start": {
-                "column": 2,
-                "line": 5,
-                "offset": 58,
-              },
-            },
-            "name": "pseudo_class_2",
-          },
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 25,
-                "line": 6,
-                "offset": 106,
-              },
-              "start": {
-                "column": 1,
-                "line": 6,
-                "offset": 82,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 21,
-                "line": 6,
-                "offset": 102,
-              },
-              "start": {
-                "column": 7,
-                "line": 6,
-                "offset": 88,
-              },
-            },
-            "name": "pseudo_class_3",
-          },
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 44,
-                "line": 7,
-                "offset": 150,
-              },
-              "start": {
-                "column": 1,
-                "line": 7,
-                "offset": 107,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 21,
-                "line": 7,
-                "offset": 127,
-              },
-              "start": {
-                "column": 2,
-                "line": 7,
-                "offset": 108,
-              },
-            },
-            "name": "multiple_selector_1",
-          },
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 44,
-                "line": 7,
-                "offset": 150,
-              },
-              "start": {
-                "column": 1,
-                "line": 7,
-                "offset": 107,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 41,
-                "line": 7,
-                "offset": 147,
-              },
-              "start": {
-                "column": 22,
-                "line": 7,
-                "offset": 128,
-              },
-            },
-            "name": "multiple_selector_2",
-          },
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 33,
-                "line": 8,
-                "offset": 183,
-              },
-              "start": {
-                "column": 1,
-                "line": 8,
-                "offset": 151,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 14,
-                "line": 8,
-                "offset": 164,
-              },
-              "start": {
-                "column": 2,
-                "line": 8,
-                "offset": 152,
-              },
-            },
-            "name": "combinator_1",
-          },
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 33,
-                "line": 8,
-                "offset": 183,
-              },
-              "start": {
-                "column": 1,
-                "line": 8,
-                "offset": 151,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 30,
-                "line": 8,
-                "offset": 180,
-              },
-              "start": {
-                "column": 18,
-                "line": 8,
-                "offset": 168,
-              },
-            },
-            "name": "combinator_2",
-          },
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 16,
-                "line": 11,
-                "offset": 268,
-              },
-              "start": {
-                "column": 5,
-                "line": 11,
-                "offset": 257,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 13,
-                "line": 11,
-                "offset": 265,
-              },
-              "start": {
-                "column": 6,
-                "line": 11,
-                "offset": 258,
-              },
-            },
-            "name": "at_rule",
-          },
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 38,
-                "line": 14,
-                "offset": 312,
-              },
-              "start": {
-                "column": 1,
-                "line": 14,
-                "offset": 275,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 17,
-                "line": 14,
-                "offset": 291,
-              },
-              "start": {
-                "column": 2,
-                "line": 14,
-                "offset": 276,
-              },
-            },
-            "name": "selector_list_1",
-          },
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 38,
-                "line": 14,
-                "offset": 312,
-              },
-              "start": {
-                "column": 1,
-                "line": 14,
-                "offset": 275,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 35,
-                "line": 14,
-                "offset": 309,
-              },
-              "start": {
-                "column": 20,
-                "line": 14,
-                "offset": 294,
-              },
-            },
-            "name": "selector_list_2",
-          },
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 20,
-                "line": 15,
-                "offset": 332,
-              },
-              "start": {
-                "column": 1,
-                "line": 15,
-                "offset": 313,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 16,
-                "line": 15,
-                "offset": 328,
-              },
-              "start": {
-                "column": 9,
-                "line": 15,
-                "offset": 321,
-              },
-            },
-            "name": "local_1",
-          },
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 22,
-                "line": 16,
-                "offset": 354,
-              },
-              "start": {
-                "column": 1,
-                "line": 16,
-                "offset": 333,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 13,
-                "line": 16,
-                "offset": 345,
-              },
-              "start": {
-                "column": 8,
-                "line": 16,
-                "offset": 340,
-              },
-            },
-            "name": "value",
-          },
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 23,
-                "line": 17,
-                "offset": 378,
-              },
-              "start": {
-                "column": 1,
-                "line": 17,
-                "offset": 356,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 20,
-                "line": 17,
-                "offset": 375,
-              },
-              "start": {
-                "column": 12,
-                "line": 17,
-                "offset": 367,
-              },
-            },
-            "name": "keyframe",
-          },
-        ],
-        "text": ".basic {}
-      .cascading {}
-      .cascading {}
-      .pseudo_class_1 {}
-      .pseudo_class_2:hover {}
-      :not(.pseudo_class_3) {}
-      .multiple_selector_1.multiple_selector_2 {}
-      .combinator_1 + .combinator_2 {}
-      @supports (display: flex) {
-        @media screen and (min-width: 900px) {
-          .at_rule {}
-        }
-      }
-      .selector_list_1, .selector_list_2 {}
-      :local(.local_1) {}
-      @value value: #BF4040;
-      @keyframes keyframe {}",
-        "tokenImporters": [],
-      }
+    	{
+    	  "diagnostics": [],
+    	  "fileName": "/test.module.css",
+    	  "localTokens": [
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 10,
+    	          "line": 1,
+    	          "offset": 9,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 1,
+    	          "offset": 0,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 7,
+    	          "line": 1,
+    	          "offset": 6,
+    	        },
+    	        "start": {
+    	          "column": 2,
+    	          "line": 1,
+    	          "offset": 1,
+    	        },
+    	      },
+    	      "name": "basic",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 14,
+    	          "line": 2,
+    	          "offset": 23,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 2,
+    	          "offset": 10,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 11,
+    	          "line": 2,
+    	          "offset": 20,
+    	        },
+    	        "start": {
+    	          "column": 2,
+    	          "line": 2,
+    	          "offset": 11,
+    	        },
+    	      },
+    	      "name": "cascading",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 14,
+    	          "line": 3,
+    	          "offset": 37,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 3,
+    	          "offset": 24,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 11,
+    	          "line": 3,
+    	          "offset": 34,
+    	        },
+    	        "start": {
+    	          "column": 2,
+    	          "line": 3,
+    	          "offset": 25,
+    	        },
+    	      },
+    	      "name": "cascading",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 19,
+    	          "line": 4,
+    	          "offset": 56,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 4,
+    	          "offset": 38,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 16,
+    	          "line": 4,
+    	          "offset": 53,
+    	        },
+    	        "start": {
+    	          "column": 2,
+    	          "line": 4,
+    	          "offset": 39,
+    	        },
+    	      },
+    	      "name": "pseudo_class_1",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 25,
+    	          "line": 5,
+    	          "offset": 81,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 5,
+    	          "offset": 57,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 16,
+    	          "line": 5,
+    	          "offset": 72,
+    	        },
+    	        "start": {
+    	          "column": 2,
+    	          "line": 5,
+    	          "offset": 58,
+    	        },
+    	      },
+    	      "name": "pseudo_class_2",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 25,
+    	          "line": 6,
+    	          "offset": 106,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 6,
+    	          "offset": 82,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 21,
+    	          "line": 6,
+    	          "offset": 102,
+    	        },
+    	        "start": {
+    	          "column": 7,
+    	          "line": 6,
+    	          "offset": 88,
+    	        },
+    	      },
+    	      "name": "pseudo_class_3",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 44,
+    	          "line": 7,
+    	          "offset": 150,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 7,
+    	          "offset": 107,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 21,
+    	          "line": 7,
+    	          "offset": 127,
+    	        },
+    	        "start": {
+    	          "column": 2,
+    	          "line": 7,
+    	          "offset": 108,
+    	        },
+    	      },
+    	      "name": "multiple_selector_1",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 44,
+    	          "line": 7,
+    	          "offset": 150,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 7,
+    	          "offset": 107,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 41,
+    	          "line": 7,
+    	          "offset": 147,
+    	        },
+    	        "start": {
+    	          "column": 22,
+    	          "line": 7,
+    	          "offset": 128,
+    	        },
+    	      },
+    	      "name": "multiple_selector_2",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 33,
+    	          "line": 8,
+    	          "offset": 183,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 8,
+    	          "offset": 151,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 14,
+    	          "line": 8,
+    	          "offset": 164,
+    	        },
+    	        "start": {
+    	          "column": 2,
+    	          "line": 8,
+    	          "offset": 152,
+    	        },
+    	      },
+    	      "name": "combinator_1",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 33,
+    	          "line": 8,
+    	          "offset": 183,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 8,
+    	          "offset": 151,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 30,
+    	          "line": 8,
+    	          "offset": 180,
+    	        },
+    	        "start": {
+    	          "column": 18,
+    	          "line": 8,
+    	          "offset": 168,
+    	        },
+    	      },
+    	      "name": "combinator_2",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 16,
+    	          "line": 11,
+    	          "offset": 268,
+    	        },
+    	        "start": {
+    	          "column": 5,
+    	          "line": 11,
+    	          "offset": 257,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 13,
+    	          "line": 11,
+    	          "offset": 265,
+    	        },
+    	        "start": {
+    	          "column": 6,
+    	          "line": 11,
+    	          "offset": 258,
+    	        },
+    	      },
+    	      "name": "at_rule",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 38,
+    	          "line": 14,
+    	          "offset": 312,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 14,
+    	          "offset": 275,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 17,
+    	          "line": 14,
+    	          "offset": 291,
+    	        },
+    	        "start": {
+    	          "column": 2,
+    	          "line": 14,
+    	          "offset": 276,
+    	        },
+    	      },
+    	      "name": "selector_list_1",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 38,
+    	          "line": 14,
+    	          "offset": 312,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 14,
+    	          "offset": 275,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 35,
+    	          "line": 14,
+    	          "offset": 309,
+    	        },
+    	        "start": {
+    	          "column": 20,
+    	          "line": 14,
+    	          "offset": 294,
+    	        },
+    	      },
+    	      "name": "selector_list_2",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 20,
+    	          "line": 15,
+    	          "offset": 332,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 15,
+    	          "offset": 313,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 16,
+    	          "line": 15,
+    	          "offset": 328,
+    	        },
+    	        "start": {
+    	          "column": 9,
+    	          "line": 15,
+    	          "offset": 321,
+    	        },
+    	      },
+    	      "name": "local_1",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 22,
+    	          "line": 16,
+    	          "offset": 354,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 16,
+    	          "offset": 333,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 13,
+    	          "line": 16,
+    	          "offset": 345,
+    	        },
+    	        "start": {
+    	          "column": 8,
+    	          "line": 16,
+    	          "offset": 340,
+    	        },
+    	      },
+    	      "name": "value",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 23,
+    	          "line": 17,
+    	          "offset": 378,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 17,
+    	          "offset": 356,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 20,
+    	          "line": 17,
+    	          "offset": 375,
+    	        },
+    	        "start": {
+    	          "column": 12,
+    	          "line": 17,
+    	          "offset": 367,
+    	        },
+    	      },
+    	      "name": "keyframe",
+    	    },
+    	  ],
+    	  "text": ".basic {}
+    	.cascading {}
+    	.cascading {}
+    	.pseudo_class_1 {}
+    	.pseudo_class_2:hover {}
+    	:not(.pseudo_class_3) {}
+    	.multiple_selector_1.multiple_selector_2 {}
+    	.combinator_1 + .combinator_2 {}
+    	@supports (display: flex) {
+    	  @media screen and (min-width: 900px) {
+    	    .at_rule {}
+    	  }
+    	}
+    	.selector_list_1, .selector_list_2 {}
+    	:local(.local_1) {}
+    	@value value: #BF4040;
+    	@keyframes keyframe {}",
+    	  "tokenImporters": [],
+    	  "tokenReferences": [],
+    	}
     `);
   });
   test('collects token importers', () => {
@@ -581,7 +582,99 @@ describe('parseCSSModule', () => {
             "type": "named",
           },
         ],
+        "tokenReferences": [],
       }
+    `);
+  });
+  test('collects token references', () => {
+    const parsed = parseCSSModule(
+      dedent`
+        @keyframes a_1 {}
+        .a_2 { animation-name: a_1; }
+      `,
+      options,
+    );
+    expect(parsed).toMatchInlineSnapshot(`
+    	{
+    	  "diagnostics": [],
+    	  "fileName": "/test.module.css",
+    	  "localTokens": [
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 18,
+    	          "line": 1,
+    	          "offset": 17,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 1,
+    	          "offset": 0,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 15,
+    	          "line": 1,
+    	          "offset": 14,
+    	        },
+    	        "start": {
+    	          "column": 12,
+    	          "line": 1,
+    	          "offset": 11,
+    	        },
+    	      },
+    	      "name": "a_1",
+    	    },
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 30,
+    	          "line": 2,
+    	          "offset": 47,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 2,
+    	          "offset": 18,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 5,
+    	          "line": 2,
+    	          "offset": 22,
+    	        },
+    	        "start": {
+    	          "column": 2,
+    	          "line": 2,
+    	          "offset": 19,
+    	        },
+    	      },
+    	      "name": "a_2",
+    	    },
+    	  ],
+    	  "text": "@keyframes a_1 {}
+    	.a_2 { animation-name: a_1; }",
+    	  "tokenImporters": [],
+    	  "tokenReferences": [
+    	    {
+    	      "loc": {
+    	        "end": {
+    	          "column": 27,
+    	          "line": 2,
+    	          "offset": 44,
+    	        },
+    	        "start": {
+    	          "column": 24,
+    	          "line": 2,
+    	          "offset": 41,
+    	        },
+    	      },
+    	      "name": "a_1",
+    	    },
+    	  ],
+    	}
     `);
   });
   test('collects diagnostics', () => {
@@ -593,80 +686,77 @@ describe('parseCSSModule', () => {
       options,
     );
     expect(parsed).toMatchInlineSnapshot(`
-      {
-        "diagnostics": [
-          {
-            "category": "error",
-            "file": {
-              "fileName": "/test.module.css",
-              "text": ":local .local1 {}
-      @value;",
-            },
-            "length": 6,
-            "start": {
-              "column": 1,
-              "line": 1,
-              "offset": 0,
-            },
-            "text": "css-modules-kit does not support \`:local\`. Use \`:local(...)\` instead.",
-          },
-          {
-            "category": "error",
-            "file": {
-              "fileName": "/test.module.css",
-              "text": ":local .local1 {}
-      @value;",
-            },
-            "length": 7,
-            "start": {
-              "column": 1,
-              "line": 2,
-            },
-            "text": "\`@value\` is a invalid syntax.",
-          },
-        ],
-        "fileName": "/test.module.css",
-        "localTokens": [
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 18,
-                "line": 1,
-                "offset": 17,
-              },
-              "start": {
-                "column": 1,
-                "line": 1,
-                "offset": 0,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 15,
-                "line": 1,
-                "offset": 14,
-              },
-              "start": {
-                "column": 9,
-                "line": 1,
-                "offset": 8,
-              },
-            },
-            "name": "local1",
-          },
-        ],
-        "text": ":local .local1 {}
-      @value;",
-        "tokenImporters": [],
-      }
+    	{
+    	  "diagnostics": [
+    	    {
+    	      "category": "error",
+    	      "file": {
+    	        "fileName": "/test.module.css",
+    	        "text": ":local .local1 {}
+    	@value;",
+    	      },
+    	      "length": 6,
+    	      "start": {
+    	        "column": 1,
+    	        "line": 1,
+    	        "offset": 0,
+    	      },
+    	      "text": "css-modules-kit does not support \`:local\`. Use \`:local(...)\` instead.",
+    	    },
+    	    {
+    	      "category": "error",
+    	      "file": {
+    	        "fileName": "/test.module.css",
+    	        "text": ":local .local1 {}
+    	@value;",
+    	      },
+    	      "length": 7,
+    	      "start": {
+    	        "column": 1,
+    	        "line": 2,
+    	      },
+    	      "text": "\`@value\` is a invalid syntax.",
+    	    },
+    	  ],
+    	  "fileName": "/test.module.css",
+    	  "localTokens": [
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 18,
+    	          "line": 1,
+    	          "offset": 17,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 1,
+    	          "offset": 0,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 15,
+    	          "line": 1,
+    	          "offset": 14,
+    	        },
+    	        "start": {
+    	          "column": 9,
+    	          "line": 1,
+    	          "offset": 8,
+    	        },
+    	      },
+    	      "name": "local1",
+    	    },
+    	  ],
+    	  "text": ":local .local1 {}
+    	@value;",
+    	  "tokenImporters": [],
+    	  "tokenReferences": [],
+    	}
     `);
   });
   // TODO: Support local tokens by CSS variables. This is supported by lightningcss.
   // https://github.com/parcel-bundler/lightningcss/blob/a3390fd4140ca87f5035595d22bc9357cf72177e/src/css_modules.rs#L34
-
-  // TODO: Support local tokens by animation names. This is supported by postcss-modules-local-by-default and lightningcss.
-  // https://github.com/css-modules/postcss-modules-local-by-default/blob/39a2f78d9f39f5c0e30dd9b2a25f4a145431cb20/test/index.test.js#L162-L399
-  // https://github.com/parcel-bundler/lightningcss/blob/a3390fd4140ca87f5035595d22bc9357cf72177e/src/css_modules.rs#L37
 
   // TODO: Support local tokens by grid names. This is supported by lightningcss.
   // https://github.com/parcel-bundler/lightningcss/blob/a3390fd4140ca87f5035595d22bc9357cf72177e/src/css_modules.rs#L40
@@ -686,78 +776,80 @@ describe('parseCSSModule', () => {
         options,
       ),
     ).toMatchInlineSnapshot(`
-      {
-        "diagnostics": [
-          {
-            "category": "error",
-            "file": {
-              "fileName": "/test.module.css",
-              "text": ".a {",
-            },
-            "length": 1,
-            "start": {
-              "column": 1,
-              "line": 1,
-            },
-            "text": "Unclosed block",
-          },
-        ],
-        "fileName": "/test.module.css",
-        "localTokens": [
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 6,
-                "line": 1,
-                "offset": 5,
-              },
-              "start": {
-                "column": 1,
-                "line": 1,
-                "offset": 0,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 3,
-                "line": 1,
-                "offset": 2,
-              },
-              "start": {
-                "column": 2,
-                "line": 1,
-                "offset": 1,
-              },
-            },
-            "name": "a",
-          },
-        ],
-        "text": ".a {",
-        "tokenImporters": [],
-      }
+    	{
+    	  "diagnostics": [
+    	    {
+    	      "category": "error",
+    	      "file": {
+    	        "fileName": "/test.module.css",
+    	        "text": ".a {",
+    	      },
+    	      "length": 1,
+    	      "start": {
+    	        "column": 1,
+    	        "line": 1,
+    	      },
+    	      "text": "Unclosed block",
+    	    },
+    	  ],
+    	  "fileName": "/test.module.css",
+    	  "localTokens": [
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 6,
+    	          "line": 1,
+    	          "offset": 5,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 1,
+    	          "offset": 0,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 3,
+    	          "line": 1,
+    	          "offset": 2,
+    	        },
+    	        "start": {
+    	          "column": 2,
+    	          "line": 1,
+    	          "offset": 1,
+    	        },
+    	      },
+    	      "name": "a",
+    	    },
+    	  ],
+    	  "text": ".a {",
+    	  "tokenImporters": [],
+    	  "tokenReferences": [],
+    	}
     `);
     expect(parseCSSModule('badword', options)).toMatchInlineSnapshot(`
-      {
-        "diagnostics": [
-          {
-            "category": "error",
-            "file": {
-              "fileName": "/test.module.css",
-              "text": "badword",
-            },
-            "length": 7,
-            "start": {
-              "column": 1,
-              "line": 1,
-            },
-            "text": "Unknown word badword",
-          },
-        ],
-        "fileName": "/test.module.css",
-        "localTokens": [],
-        "text": "badword",
-        "tokenImporters": [],
-      }
+    	{
+    	  "diagnostics": [
+    	    {
+    	      "category": "error",
+    	      "file": {
+    	        "fileName": "/test.module.css",
+    	        "text": "badword",
+    	      },
+    	      "length": 7,
+    	      "start": {
+    	        "column": 1,
+    	        "line": 1,
+    	      },
+    	      "text": "Unknown word badword",
+    	    },
+    	  ],
+    	  "fileName": "/test.module.css",
+    	  "localTokens": [],
+    	  "text": "badword",
+    	  "tokenImporters": [],
+    	  "tokenReferences": [],
+    	}
     `);
   });
   test('does not include syntax error in diagnostics if includeSyntaxError is false', () => {
@@ -769,41 +861,42 @@ describe('parseCSSModule', () => {
         { ...options, includeSyntaxError: false },
       ),
     ).toMatchInlineSnapshot(`
-      {
-        "diagnostics": [],
-        "fileName": "/test.module.css",
-        "localTokens": [
-          {
-            "declarationLoc": {
-              "end": {
-                "column": 6,
-                "line": 1,
-                "offset": 5,
-              },
-              "start": {
-                "column": 1,
-                "line": 1,
-                "offset": 0,
-              },
-            },
-            "loc": {
-              "end": {
-                "column": 3,
-                "line": 1,
-                "offset": 2,
-              },
-              "start": {
-                "column": 2,
-                "line": 1,
-                "offset": 1,
-              },
-            },
-            "name": "a",
-          },
-        ],
-        "text": ".a {",
-        "tokenImporters": [],
-      }
+    	{
+    	  "diagnostics": [],
+    	  "fileName": "/test.module.css",
+    	  "localTokens": [
+    	    {
+    	      "declarationLoc": {
+    	        "end": {
+    	          "column": 6,
+    	          "line": 1,
+    	          "offset": 5,
+    	        },
+    	        "start": {
+    	          "column": 1,
+    	          "line": 1,
+    	          "offset": 0,
+    	        },
+    	      },
+    	      "loc": {
+    	        "end": {
+    	          "column": 3,
+    	          "line": 1,
+    	          "offset": 2,
+    	        },
+    	        "start": {
+    	          "column": 2,
+    	          "line": 1,
+    	          "offset": 1,
+    	        },
+    	      },
+    	      "name": "a",
+    	    },
+    	  ],
+    	  "text": ".a {",
+    	  "tokenImporters": [],
+    	  "tokenReferences": [],
+    	}
     `);
   });
   test('does not include the token of keyframes if keyframes is false', () => {

--- a/packages/core/src/parser/css-module-parser.ts
+++ b/packages/core/src/parser/css-module-parser.ts
@@ -1,4 +1,4 @@
-import type { AtRule, Node, Root, Rule } from 'postcss';
+import type { AtRule, Declaration, Node, Root, Rule } from 'postcss';
 import { CssSyntaxError, parse } from 'postcss';
 import safeParser from 'postcss-safe-parser';
 import type {
@@ -7,7 +7,9 @@ import type {
   DiagnosticWithLocation,
   Token,
   TokenImporter,
+  TokenReference,
 } from '../type.js';
+import { isAnimationNameProp, parseAnimationNameProp } from './animation-parser.js';
 import { parseAtImport } from './at-import-parser.js';
 import { parseAtValue } from './at-value-parser.js';
 import { parseAtKeyframes } from './key-frame-parser.js';
@@ -37,6 +39,10 @@ function isRuleNode(node: Node): node is Rule {
   return node.type === 'rule';
 }
 
+function isDeclarationNode(node: Node): node is Declaration {
+  return node.type === 'decl';
+}
+
 /**
  * Collect tokens from the AST.
  */
@@ -44,6 +50,7 @@ function collectTokens(ast: Root, keyframes: boolean) {
   const allDiagnostics: DiagnosticWithDetachedLocation[] = [];
   const localTokens: Token[] = [];
   const tokenImporters: TokenImporter[] = [];
+  const tokenReferences: TokenReference[] = [];
   ast.walk((node) => {
     if (isAtImportNode(node)) {
       const parsed = parseAtImport(node);
@@ -72,9 +79,13 @@ function collectTokens(ast: Root, keyframes: boolean) {
       for (const classSelector of classSelectors) {
         localTokens.push(classSelector);
       }
+    } else if (keyframes && isDeclarationNode(node) && isAnimationNameProp(node.prop)) {
+      const { references, diagnostics } = parseAnimationNameProp(node);
+      allDiagnostics.push(...diagnostics);
+      tokenReferences.push(...references);
     }
   });
-  return { localTokens, tokenImporters, diagnostics: allDiagnostics };
+  return { localTokens, tokenImporters, tokenReferences, diagnostics: allDiagnostics };
 }
 
 export interface ParseCSSModuleOptions {
@@ -116,13 +127,14 @@ export function parseCSSModule(
     ast = safeParser(text, { from: fileName });
   }
 
-  const { localTokens, tokenImporters, diagnostics } = collectTokens(ast, keyframes);
+  const { localTokens, tokenImporters, tokenReferences, diagnostics } = collectTokens(ast, keyframes);
   allDiagnostics.push(...diagnostics.map((diagnostic) => ({ ...diagnostic, file: diagnosticFile })));
   return {
     fileName,
     text,
     localTokens,
     tokenImporters,
+    tokenReferences,
     diagnostics: allDiagnostics,
   };
 }

--- a/packages/core/src/test/ast.ts
+++ b/packages/core/src/test/ast.ts
@@ -1,4 +1,4 @@
-import type { AtRule, Root, Rule } from 'postcss';
+import type { AtRule, Declaration, Root, Rule } from 'postcss';
 import { parse } from 'postcss';
 import type { ClassName } from 'postcss-selector-parser';
 import selectorParser from 'postcss-selector-parser';
@@ -51,4 +51,13 @@ export function fakeAtKeyframes(root: Root): AtRule[] {
     results.push(atKeyframes);
   });
   return results;
+}
+
+export function fakeDeclaration(css: string): Declaration {
+  const root = fakeRoot(css);
+  const rule = root.first;
+  if (rule === undefined || rule.type !== 'rule') throw new Error('expected a rule');
+  const decl = rule.first;
+  if (decl === undefined || decl.type !== 'decl') throw new Error('expected a declaration');
+  return decl;
 }

--- a/packages/core/src/test/css-module.ts
+++ b/packages/core/src/test/css-module.ts
@@ -8,12 +8,13 @@ export function fakeCSSModule(args?: Partial<CSSModule>): CSSModule {
     text: '',
     localTokens: [],
     tokenImporters: [],
+    tokenReferences: [],
     diagnostics: [],
     ...args,
   };
 }
 
-export function readAndParseCSSModule(path: string): CSSModule | undefined {
+export function readAndParseCSSModule(path: string, options?: { keyframes?: boolean }): CSSModule | undefined {
   let text: string;
   try {
     text = readFileSync(path, 'utf-8');
@@ -23,6 +24,6 @@ export function readAndParseCSSModule(path: string): CSSModule | undefined {
   return parseCSSModule(text, {
     fileName: path,
     includeSyntaxError: false,
-    keyframes: false,
+    keyframes: options?.keyframes ?? true,
   });
 }

--- a/packages/core/src/type.ts
+++ b/packages/core/src/type.ts
@@ -97,6 +97,23 @@ export interface NamedTokenImporterEntry {
 
 export type TokenImporter = AllTokenImporter | NamedTokenImporter;
 
+/**
+ * A reference to a token from a CSS Module file.
+ *
+ * For example, `animation-name: foo;` references the `foo` token. The token
+ * itself may be defined in the same file (e.g. by `@keyframes foo {...}`) or
+ * imported from another file (e.g. via `@import`). Token references connect
+ * the usage site to the declaration site so that language features (Go to
+ * Definition, Find All References, Rename) work consistently across
+ * `@keyframes` definitions and `animation-name` references.
+ */
+export interface TokenReference {
+  /** The referenced token name. */
+  name: string;
+  /** The location of the reference name in the source file. */
+  loc: Location;
+}
+
 export interface CSSModule {
   /** Absolute path of the file */
   fileName: string;
@@ -118,6 +135,8 @@ export interface CSSModule {
    * Token importer is a statement that imports tokens from another file.
    */
   tokenImporters: TokenImporter[];
+  /** List of token references in this file. */
+  tokenReferences: TokenReference[];
   /** Diagnostics found during parsing. */
   diagnostics: DiagnosticWithLocation[];
 }

--- a/packages/core/src/util.test.ts
+++ b/packages/core/src/util.test.ts
@@ -1,6 +1,6 @@
 import dedent from 'dedent';
 import { describe, expect, test } from 'vite-plus/test';
-import { fakeCSSModule } from './test/css-module.js';
+import { fakeRoot } from './test/ast.js';
 import { findUsedTokenNames, validateTokenName } from './util.js';
 
 describe('validateTokenName', () => {
@@ -40,15 +40,10 @@ describe('findUsedTokenNames', () => {
       styles;
     `;
     const expected = new Set(['a_1', 'a_2', 'a-3', 'a-4', 'a_6']);
-    expect(findUsedTokenNames(text, fakeCSSModule())).toEqual(expected);
+    expect(findUsedTokenNames(text, fakeRoot(''))).toEqual(expected);
   });
-  test('collects token names referenced from token references in the CSS module', () => {
-    const cssModule = fakeCSSModule({
-      tokenReferences: [
-        { name: 'a_1', loc: { start: { line: 1, column: 1, offset: 0 }, end: { line: 1, column: 1, offset: 0 } } },
-        { name: 'a_2', loc: { start: { line: 1, column: 1, offset: 0 }, end: { line: 1, column: 1, offset: 0 } } },
-      ],
-    });
-    expect(findUsedTokenNames('styles.a_3;', cssModule)).toEqual(new Set(['a_1', 'a_2', 'a_3']));
+  test('collects token names referenced from animation-name in the CSS module', () => {
+    const root = fakeRoot('.a_3 { animation-name: a_1, a_2; }');
+    expect(findUsedTokenNames('styles.a_3;', root)).toEqual(new Set(['a_1', 'a_2', 'a_3']));
   });
 });

--- a/packages/core/src/util.test.ts
+++ b/packages/core/src/util.test.ts
@@ -1,5 +1,6 @@
 import dedent from 'dedent';
 import { describe, expect, test } from 'vite-plus/test';
+import { fakeCSSModule } from './test/css-module.js';
 import { findUsedTokenNames, validateTokenName } from './util.js';
 
 describe('validateTokenName', () => {
@@ -23,20 +24,31 @@ describe('validateTokenName', () => {
   });
 });
 
-test('findUsedTokenNames', () => {
-  const text = dedent`
-    import styles from './a.module.css';
-    styles.a_1;
-    styles.a_1;
-    styles.a_2;
-    styles['a-3'];
-    styles["a-4"];
-    styles[\`a-5\`];
-    // styles.a_6; // false positive, but it is acceptable for simplicity of implementation
-    styles['a-7;
-    styles['a-8"];
-    styles;
-  `;
-  const expected = new Set(['a_1', 'a_2', 'a-3', 'a-4', 'a_6']);
-  expect(findUsedTokenNames(text)).toEqual(expected);
+describe('findUsedTokenNames', () => {
+  test('collects token names referenced from the component file', () => {
+    const text = dedent`
+      import styles from './a.module.css';
+      styles.a_1;
+      styles.a_1;
+      styles.a_2;
+      styles['a-3'];
+      styles["a-4"];
+      styles[\`a-5\`];
+      // styles.a_6; // false positive, but it is acceptable for simplicity of implementation
+      styles['a-7;
+      styles['a-8"];
+      styles;
+    `;
+    const expected = new Set(['a_1', 'a_2', 'a-3', 'a-4', 'a_6']);
+    expect(findUsedTokenNames(text, fakeCSSModule())).toEqual(expected);
+  });
+  test('collects token names referenced from token references in the CSS module', () => {
+    const cssModule = fakeCSSModule({
+      tokenReferences: [
+        { name: 'a_1', loc: { start: { line: 1, column: 1, offset: 0 }, end: { line: 1, column: 1, offset: 0 } } },
+        { name: 'a_2', loc: { start: { line: 1, column: 1, offset: 0 }, end: { line: 1, column: 1, offset: 0 } } },
+      ],
+    });
+    expect(findUsedTokenNames('styles.a_3;', cssModule)).toEqual(new Set(['a_1', 'a_2', 'a_3']));
+  });
 });

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -1,4 +1,5 @@
-import type { CSSModule } from './type.js';
+import type { Root } from 'postcss';
+import { isAnimationNameProp, parseAnimationNameProp } from './parser/animation-parser.js';
 
 export function isPosixRelativePath(path: string): boolean {
   return path.startsWith(`./`) || path.startsWith(`../`);
@@ -36,16 +37,28 @@ export function validateTokenName(name: string, options: ValidateTokenNameOption
 const TOKEN_CONSUMER_PATTERN =
   /styles(?:\.([$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*)|\['([^']*?)'\]|\["([^"]*?)"\])/gu;
 
-/** Returns the set of token names that are considered used. */
-export function findUsedTokenNames(componentText: string, cssModule: CSSModule): Set<string> {
+/**
+ * Returns the set of token names that are considered used.
+ *
+ * A token name is considered used if it is referenced from the component file
+ * (via a `styles.<name>` style pattern) or from within the CSS module itself
+ * (e.g. via `animation-name: <name>`). The latter is collected by walking
+ * `root` so that callers can pass an already-parsed PostCSS AST to avoid an
+ * extra parse.
+ */
+export function findUsedTokenNames(componentText: string, root: Root): Set<string> {
   const usedClassNames = new Set<string>();
   for (const match of componentText.matchAll(TOKEN_CONSUMER_PATTERN)) {
     const name = match[1] ?? match[2] ?? match[3];
     if (name) usedClassNames.add(name);
   }
-  for (const reference of cssModule.tokenReferences) {
-    usedClassNames.add(reference.name);
-  }
+  root.walkDecls((decl) => {
+    if (!isAnimationNameProp(decl.prop)) return;
+    const { references } = parseAnimationNameProp(decl);
+    for (const reference of references) {
+      usedClassNames.add(reference.name);
+    }
+  });
   return usedClassNames;
 }
 

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -1,3 +1,5 @@
+import type { CSSModule } from './type.js';
+
 export function isPosixRelativePath(path: string): boolean {
   return path.startsWith(`./`) || path.startsWith(`../`);
 }
@@ -34,11 +36,15 @@ export function validateTokenName(name: string, options: ValidateTokenNameOption
 const TOKEN_CONSUMER_PATTERN =
   /styles(?:\.([$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*)|\['([^']*?)'\]|\["([^"]*?)"\])/gu;
 
-export function findUsedTokenNames(componentText: string): Set<string> {
+/** Returns the set of token names that are considered used. */
+export function findUsedTokenNames(componentText: string, cssModule: CSSModule): Set<string> {
   const usedClassNames = new Set<string>();
   for (const match of componentText.matchAll(TOKEN_CONSUMER_PATTERN)) {
     const name = match[1] ?? match[2] ?? match[3];
     if (name) usedClassNames.add(name);
+  }
+  for (const reference of cssModule.tokenReferences) {
+    usedClassNames.add(reference.name);
   }
   return usedClassNames;
 }

--- a/packages/eslint-plugin/src/rules/no-unused-class-names.test.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-class-names.test.ts
@@ -70,6 +70,28 @@ describe('no-unused-class-names', () => {
       ]
     `);
   });
+  test('does not warn names referenced via animation-name in the same CSS', async () => {
+    const iff = await createIFF({
+      'a.module.css': dedent`
+        .local1 {}
+        .local2 { animation-name: local1; }
+      `,
+      'a.tsx': dedent`
+        import styles from './a.module.css';
+        styles.local2;
+      `,
+    });
+    const eslint = createESLint(iff.rootDir, config);
+    const results = await eslint.lintFiles(iff.rootDir);
+    expect(formatLintResults(results, iff.rootDir)).toMatchInlineSnapshot(`
+      [
+        {
+          "filePath": "<rootDir>/a.module.css",
+          "messages": [],
+        },
+      ]
+    `);
+  });
   test('does not warn if ts file is not found', async () => {
     const iff = await createIFF({
       'a.module.css': dedent`

--- a/packages/eslint-plugin/src/rules/no-unused-class-names.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-class-names.ts
@@ -1,11 +1,4 @@
-import {
-  basename,
-  findComponentFileSync,
-  findUsedTokenNames,
-  isCSSModuleFile,
-  parseCSSModule,
-  parseRule,
-} from '@css-modules-kit/core';
+import { basename, findComponentFileSync, findUsedTokenNames, isCSSModuleFile, parseRule } from '@css-modules-kit/core';
 import type { Rule } from 'eslint';
 import safeParser from 'postcss-safe-parser';
 import { readFile } from '../util.js';
@@ -34,14 +27,9 @@ export const noUnusedClassNames: Rule.RuleModule = {
     // assumed that all class names are used.
     if (componentFile === undefined) return {};
 
-    const cssModule = parseCSSModule(context.sourceCode.text, {
-      fileName,
-      includeSyntaxError: false,
-      keyframes: true,
-    });
-    const usedTokenNames = findUsedTokenNames(componentFile.text, cssModule);
-
     const root = safeParser(context.sourceCode.text, { from: fileName });
+    const usedTokenNames = findUsedTokenNames(componentFile.text, root);
+
     root.walkRules((rule) => {
       const { classSelectors } = parseRule(rule);
 

--- a/packages/eslint-plugin/src/rules/no-unused-class-names.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-class-names.ts
@@ -1,4 +1,11 @@
-import { basename, findComponentFileSync, findUsedTokenNames, isCSSModuleFile, parseRule } from '@css-modules-kit/core';
+import {
+  basename,
+  findComponentFileSync,
+  findUsedTokenNames,
+  isCSSModuleFile,
+  parseCSSModule,
+  parseRule,
+} from '@css-modules-kit/core';
 import type { Rule } from 'eslint';
 import safeParser from 'postcss-safe-parser';
 import { readFile } from '../util.js';
@@ -27,7 +34,12 @@ export const noUnusedClassNames: Rule.RuleModule = {
     // assumed that all class names are used.
     if (componentFile === undefined) return {};
 
-    const usedTokenNames = findUsedTokenNames(componentFile.text);
+    const cssModule = parseCSSModule(context.sourceCode.text, {
+      fileName,
+      includeSyntaxError: false,
+      keyframes: true,
+    });
+    const usedTokenNames = findUsedTokenNames(componentFile.text, cssModule);
 
     const root = safeParser(context.sourceCode.text, { from: fileName });
     root.walkRules((rule) => {

--- a/packages/stylelint-plugin/src/rules/no-unused-class-names.test.ts
+++ b/packages/stylelint-plugin/src/rules/no-unused-class-names.test.ts
@@ -78,6 +78,27 @@ describe('no-unused-class-names', () => {
       ]
     `);
   });
+  test('does not warn names referenced via animation-name in the same CSS', async () => {
+    const iff = await createIFF({
+      'a.module.css': dedent`
+        .local1 {}
+        .local2 { animation-name: local1; }
+      `,
+      'a.tsx': dedent`
+        import styles from './a.module.css';
+        styles.local2;
+      `,
+    });
+    const results = await lint(iff.rootDir);
+    expect(formatLinterResult(results, iff.rootDir)).toMatchInlineSnapshot(`
+      [
+        {
+          "source": "<rootDir>/a.module.css",
+          "warnings": [],
+        },
+      ]
+    `);
+  });
   test('does not warn if ts file is not found', async () => {
     const iff = await createIFF({
       'a.module.css': dedent`

--- a/packages/stylelint-plugin/src/rules/no-unused-class-names.ts
+++ b/packages/stylelint-plugin/src/rules/no-unused-class-names.ts
@@ -1,11 +1,4 @@
-import {
-  basename,
-  findComponentFile,
-  findUsedTokenNames,
-  isCSSModuleFile,
-  parseCSSModule,
-  parseRule,
-} from '@css-modules-kit/core';
+import { basename, findComponentFile, findUsedTokenNames, isCSSModuleFile, parseRule } from '@css-modules-kit/core';
 import type { Rule, RuleMeta } from 'stylelint';
 import stylelint from 'stylelint';
 import { readFile } from '../util.js';
@@ -35,12 +28,7 @@ const ruleFunction: Rule = (_primaryOptions, _secondaryOptions, _context) => {
     // assumed that all class names are used.
     if (componentFile === undefined) return;
 
-    const cssModule = parseCSSModule(root.toString(), {
-      fileName,
-      includeSyntaxError: false,
-      keyframes: true,
-    });
-    const usedTokenNames = findUsedTokenNames(componentFile.text, cssModule);
+    const usedTokenNames = findUsedTokenNames(componentFile.text, root);
 
     root.walkRules((rule) => {
       const { classSelectors } = parseRule(rule);

--- a/packages/stylelint-plugin/src/rules/no-unused-class-names.ts
+++ b/packages/stylelint-plugin/src/rules/no-unused-class-names.ts
@@ -1,4 +1,11 @@
-import { basename, findComponentFile, findUsedTokenNames, isCSSModuleFile, parseRule } from '@css-modules-kit/core';
+import {
+  basename,
+  findComponentFile,
+  findUsedTokenNames,
+  isCSSModuleFile,
+  parseCSSModule,
+  parseRule,
+} from '@css-modules-kit/core';
 import type { Rule, RuleMeta } from 'stylelint';
 import stylelint from 'stylelint';
 import { readFile } from '../util.js';
@@ -28,7 +35,12 @@ const ruleFunction: Rule = (_primaryOptions, _secondaryOptions, _context) => {
     // assumed that all class names are used.
     if (componentFile === undefined) return;
 
-    const usedTokenNames = findUsedTokenNames(componentFile.text);
+    const cssModule = parseCSSModule(root.toString(), {
+      fileName,
+      includeSyntaxError: false,
+      keyframes: true,
+    });
+    const usedTokenNames = findUsedTokenNames(componentFile.text, cssModule);
 
     root.walkRules((rule) => {
       const { classSelectors } = parseRule(rule);

--- a/packages/ts-plugin/e2e-test/find-all-references.test.ts
+++ b/packages/ts-plugin/e2e-test/find-all-references.test.ts
@@ -289,4 +289,56 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
   });
+
+  describe('for a token reference', () => {
+    test('from a token definition', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': dedent`
+          @keyframes a_1 { from {} to {} }
+          .a_2 { animation-name: a_1; }
+          .a_3 { animation-name: a_1; }
+        `,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendReferences({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'a_1', 0),
+      });
+
+      expect(normalizeRefItems(res.body?.refs ?? [])).toStrictEqual(
+        normalizeRefItems([
+          { file: formatPath(iff.paths['a.module.css']), ...getRange('a.module.css', 'a_1', 0) },
+          { file: formatPath(iff.paths['a.module.css']), ...getRange('a.module.css', 'a_1', 1) },
+          { file: formatPath(iff.paths['a.module.css']), ...getRange('a.module.css', 'a_1', 2) },
+        ]),
+      );
+    });
+
+    test('from a token reference', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': dedent`
+          @keyframes a_1 { from {} to {} }
+          .a_2 { animation-name: a_1; }
+          .a_3 { animation-name: a_1; }
+        `,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendReferences({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'a_1', 1),
+      });
+
+      expect(normalizeRefItems(res.body?.refs ?? [])).toStrictEqual(
+        normalizeRefItems([
+          { file: formatPath(iff.paths['a.module.css']), ...getRange('a.module.css', 'a_1', 0) },
+          { file: formatPath(iff.paths['a.module.css']), ...getRange('a.module.css', 'a_1', 1) },
+          { file: formatPath(iff.paths['a.module.css']), ...getRange('a.module.css', 'a_1', 2) },
+        ]),
+      );
+    });
+  });
 });

--- a/packages/ts-plugin/e2e-test/go-to-definition.test.ts
+++ b/packages/ts-plugin/e2e-test/go-to-definition.test.ts
@@ -432,4 +432,135 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
   });
+
+  describe('for a token reference', () => {
+    test('from a token reference', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': dedent`
+          @keyframes a_1 { from {} to {} }
+          .a_2 { animation-name: a_1; }
+        `,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'a_1', 1),
+      });
+
+      const { start: contextStart, end: contextEnd } = getRange('a.module.css', '@keyframes a_1 { from {} to {} }');
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['a.module.css']),
+            ...getRange('a.module.css', 'a_1', 0),
+            contextStart,
+            contextEnd,
+          },
+        ]),
+      );
+    });
+
+    test('from each <name> in a multi-value token reference', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': dedent`
+          @keyframes a_1 { from {} to {} }
+          @keyframes a_2 { from {} to {} }
+          .a_3 { animation-name: a_1, a_2; }
+        `,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const a1Res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'a_1', 1),
+      });
+      expect(normalizeDefinitions(a1Res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['a.module.css']),
+            ...getRange('a.module.css', 'a_1', 0),
+            ...(({ start, end }) => ({ contextStart: start, contextEnd: end }))(
+              getRange('a.module.css', '@keyframes a_1 { from {} to {} }'),
+            ),
+          },
+        ]),
+      );
+
+      const a2Res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'a_2', 1),
+      });
+      expect(normalizeDefinitions(a2Res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['a.module.css']),
+            ...getRange('a.module.css', 'a_2', 0),
+            ...(({ start, end }) => ({ contextStart: start, contextEnd: end }))(
+              getRange('a.module.css', '@keyframes a_2 { from {} to {} }'),
+            ),
+          },
+        ]),
+      );
+    });
+
+    test('from a kebab-case token reference', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': dedent`
+          @keyframes a-1 { from {} to {} }
+          .a_2 { animation-name: a-1; }
+        `,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'a-1', 1),
+      });
+
+      const { start: contextStart, end: contextEnd } = getRange('a.module.css', '@keyframes a-1 { from {} to {} }');
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['a.module.css']),
+            ...getRange('a.module.css', 'a-1', 0),
+            contextStart,
+            contextEnd,
+          },
+        ]),
+      );
+    });
+
+    test('from a token reference whose target is imported', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': dedent`
+          @import './b.module.css';
+          .a_1 { animation-name: b_1; }
+        `,
+        'b.module.css': `@keyframes b_1 { from {} to {} }`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'b_1'),
+      });
+
+      const { start: contextStart, end: contextEnd } = getRange('b.module.css', '@keyframes b_1 { from {} to {} }');
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            ...getRange('b.module.css', 'b_1'),
+            contextStart,
+            contextEnd,
+          },
+        ]),
+      );
+    });
+  });
 });

--- a/packages/ts-plugin/e2e-test/rename-symbol.test.ts
+++ b/packages/ts-plugin/e2e-test/rename-symbol.test.ts
@@ -269,4 +269,66 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
   });
+
+  describe('for a token reference', () => {
+    test('from a token definition', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': dedent`
+          @keyframes a_1 { from {} to {} }
+          .a_2 { animation-name: a_1; }
+          .a_3 { animation-name: a_1; }
+        `,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendRename({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'a_1', 0),
+      });
+
+      expect(normalizeSpanGroups(res.body?.locs ?? [])).toStrictEqual(
+        normalizeSpanGroups([
+          {
+            file: formatPath(iff.paths['a.module.css']),
+            locs: [
+              getRange('a.module.css', 'a_1', 0),
+              getRange('a.module.css', 'a_1', 1),
+              getRange('a.module.css', 'a_1', 2),
+            ],
+          },
+        ]),
+      );
+    });
+
+    test('from a token reference', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': dedent`
+          @keyframes a_1 { from {} to {} }
+          .a_2 { animation-name: a_1; }
+          .a_3 { animation-name: a_1; }
+        `,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendRename({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'a_1', 1),
+      });
+
+      expect(normalizeSpanGroups(res.body?.locs ?? [])).toStrictEqual(
+        normalizeSpanGroups([
+          {
+            file: formatPath(iff.paths['a.module.css']),
+            locs: [
+              getRange('a.module.css', 'a_1', 0),
+              getRange('a.module.css', 'a_1', 1),
+              getRange('a.module.css', 'a_1', 2),
+            ],
+          },
+        ]),
+      );
+    });
+  });
 });


### PR DESCRIPTION
closes #212

## Summary

Support resolving references from `animation-name: foo;` to `@keyframes foo {...}`.

https://github.com/user-attachments/assets/9dfe2f34-dc7d-448c-bdf5-2ad2ef1cb98b

## Implementation notes

- Add `tokenReferences: TokenReference[]` to `CSSModule`, introducing the "reference" concept paired with `localTokens` (definitions).
- New parser `packages/core/src/parser/animation-parser.ts` extracts token references from `animation-name` declarations.
- Append reference expressions (`styles['foo'];` / `__self['foo'];`) to the tail of `packages/core/src/dts-generator.ts` output so that the TS language service resolves them via Volar.js mappings.
- In named export mode, emit `declare const __self: typeof import('./<self>');` once, and reference each token via `__self['foo']`. This unifies handling of local and cross-file references in a single mechanism.
- Emit two diagnostics for invalid usage: a parse-time error for malformed `local(...)` calls (empty, multiple identifiers, or non-identifier nodes such as a nested function), and a check-time error `Cannot find token '<name>'.` for references that resolve to neither a locally defined nor imported token.
- Extend `findUsedTokenNames` to also include `tokenReferences[].name`, so the `no-unused-class-names` rule in eslint-plugin / stylelint-plugin no longer false-positives on names referenced via `animation-name` within the same CSS.

## Test plan

- [x] `vp test` (unit + e2e) passes
- [x] `vp check` (format/lint/typecheck) passes
- [x] Manual verification by opening examples in VS Code:
  - [x] Go to Definition in both directions between `@keyframes foo` and `animation-name: foo`
  - [x] Find All References on `@keyframes foo`
  - [x] Rename Symbol on `@keyframes foo`
  - [x] Cross-file references (via `@import`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)