### PR TITLE
chore: add eslint-plugin and stylelint-plugin to root devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@changesets/cli": "^2.30.0",
     "@changesets/types": "^6.1.0",
     "@css-modules-kit/codegen": "workspace:^",
+    "@css-modules-kit/eslint-plugin": "workspace:^",
+    "@css-modules-kit/stylelint-plugin": "workspace:^",
     "@eslint/css": "^1.1.0",
     "@mizdra/inline-fixture-files": "^2.1.1",
     "@mizdra/oxfmt-config": "^0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,12 @@ importers:
       '@css-modules-kit/codegen':
         specifier: workspace:^
         version: link:packages/codegen
+      '@css-modules-kit/eslint-plugin':
+        specifier: workspace:^
+        version: link:packages/eslint-plugin
+      '@css-modules-kit/stylelint-plugin':
+        specifier: workspace:^
+        version: link:packages/stylelint-plugin
       '@eslint/css':
         specifier: ^1.1.0
         version: 1.1.0


### PR DESCRIPTION
## Summary

Fix an issue where ESLint / Stylelint fail to load their config in `examples/1-basic`
because `@css-modules-kit/eslint-plugin` and `@css-modules-kit/stylelint-plugin/recommended`
cannot be resolved.

`examples/*` directories are not part of the pnpm workspace, so their dependencies must
be resolvable from the monorepo root's `node_modules`. These two plugins were missing
from the root `devDependencies`, which caused the resolution to fail.

## Repro

```sh
cd examples/1-basic
vp exec stylelint "src/**/*.css"
# ConfigurationError: Could not find "@css-modules-kit/stylelint-plugin/recommended".
vp exec eslint "src/**/*.css"
# Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@css-modules-kit/eslint-plugin'
```

## Fix

Add the following two entries to `devDependencies` in the root `package.json`:

- `@css-modules-kit/eslint-plugin: workspace:^`
- `@css-modules-kit/stylelint-plugin: workspace:^`

## Test plan

- [x] `cd examples/1-basic && vp exec stylelint "src/**/*.css"` runs without config errors
- [x] `cd examples/1-basic && vp exec eslint "src/**/*.css"` runs without config errors
- [x] `vp check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)