### PR TITLE
docs(core): clarify that the package is for internal use and may break without notice

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,8 @@
+# `@css-modules-kit/core`
+
+The core of css-modules-kit.
+
+> [!WARNING]
+> This package is intended for internal use by `@css-modules-kit/*` packages only. Using it from outside the `@css-modules-kit` ecosystem is not supported.
+>
+> Breaking changes may be introduced in any release, including minor and patch versions, without prior notice.


### PR DESCRIPTION
## Summary

Add a README to `@css-modules-kit/core` to clarify its support policy:

- This package is intended for internal use by `@css-modules-kit/*` packages only; consumption from outside the `@css-modules-kit` ecosystem is not supported.
- Breaking changes may be introduced in any release, including minor and patch versions, without prior notice.

These conditions were previously implicit. Documenting them explicitly should help prevent external consumers from unintentionally depending on this package.

## Notes

The warning uses GitHub's alert syntax (`> [!WARNING]`). On GitHub it renders as a styled callout, but on npmjs.com it renders as a plain blockquote with the literal `[!WARNING]` marker visible (npm does not natively support GitHub alerts). This is acceptable: the message is still readable on npm, and the goal is just to communicate the policy.

## Test plan

- [x] Verify the README renders as intended on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)