### PR TITLE
chore(vscode): run extension tests as ESM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  VSCODE_VERSION: '1.103.0'
+  VSCODE_VERSION: '1.119.0'
 
 jobs:
   lint:

--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -5,10 +5,7 @@ const baseConfig = {
   version: process.env.VSCODE_VERSION ?? 'stable',
   mocha: {
     timeout: 30_000,
-    // If the test file is ESM, importing 'vscode' can cause a deadlock.
-    // ref: https://github.com/microsoft/vscode-test-cli/issues/77#issuecomment-3696907905
-    // Therefore, we transpile with tsx to CJS before executing.
-    require: ['tsx/cjs', './scripts/vscode-test-setup.ts'],
+    require: ['tsx/esm', './scripts/vscode-test-setup.ts'],
   },
   download: {
     timeout: 60_000,

--- a/scripts/vscode-test-setup.ts
+++ b/scripts/vscode-test-setup.ts
@@ -2,7 +2,7 @@ import { execSync } from 'node:child_process';
 // oxlint-disable-next-line no-restricted-imports
 import { resolve } from 'node:path';
 
-const root = resolve(__dirname, '..');
+const root = resolve(import.meta.dirname, '..');
 
 export function mochaGlobalSetup() {
   execSync('vp run build', { stdio: 'inherit', cwd: root });


### PR DESCRIPTION
## Summary

- The deadlock that occurred when importing `vscode` from ESM test files has been fixed in vscode-test-cli (microsoft/vscode-test-cli#77).
- Switched the test runner in `.vscode-test.js` from `tsx/cjs` to `tsx/esm`, and removed the workaround (and its comment) that transpiled tests to CJS.
- Replaced `__dirname` in `scripts/vscode-test-setup.ts` with the ESM-compatible `import.meta.dirname`.
- Bumped `VSCODE_VERSION` in CI from `1.103.0` to `1.119.0` to pick up the fix.

## Test plan

- [x] `vp run vscode-test` passes locally
- [x] The CI `vscode-test` job passes on VSCode 1.119.0