### PR TITLE
fix(core): make default-export `styles` type-readonly via `as const`

### DIFF
--- a/.changeset/drop-readonly-string-cast.md
+++ b/.changeset/drop-readonly-string-cast.md
@@ -1,0 +1,7 @@
+---
+'@css-modules-kit/core': patch
+---
+
+fix(core): make default-export `styles` type-readonly via `as const`
+
+The default-export `.d.ts` previously emitted each token as `'<name>': '' as readonly string,`. The `readonly` modifier is only valid on array/tuple types, so this was a TypeScript syntax error silently suppressed by `@ts-nocheck` — `styles` was not actually readonly and writes like `styles.foo = '...'` were accepted by `tsc`. The generator now emits `'<name>': '' as string,` per token and closes the object literal with `} as const`, so `typeof styles` is `Readonly<{ ... }>` and writes to it are now correctly reported as type errors.

--- a/docs/ts-plugin-internals.ja.md
+++ b/docs/ts-plugin-internals.ja.md
@@ -321,9 +321,9 @@ default export の場合、次のような型定義が生成されます:
 
 ```ts
 declare const styles = {
-  'a_1': '' as readonly string,
-  'a_2': '' as readonly string,
-};
+  'a_1': '' as string,
+  'a_2': '' as string,
+} as const;
 styles['a_1'];
 export default styles;
 ```

--- a/docs/ts-plugin-internals.md
+++ b/docs/ts-plugin-internals.md
@@ -324,9 +324,9 @@ For default export, the following type definition is generated:
 
 ```ts
 declare const styles = {
-  'a_1': '' as readonly string,
-  'a_2': '' as readonly string,
-};
+  'a_1': '' as string,
+  'a_2': '' as string,
+} as const;
 styles['a_1'];
 export default styles;
 ```

--- a/examples/1-basic/generated/src/a.module.css.d.ts
+++ b/examples/1-basic/generated/src/a.module.css.d.ts
@@ -1,15 +1,15 @@
 // @ts-nocheck
 function blockErrorType<T>(val: T): [0] extends [(1 & T)] ? {} : T;
 declare const styles = {
-  'a_1': '' as readonly string,
-  'a_2': '' as readonly string,
-  'a_2': '' as readonly string,
-  'a_3': '' as readonly string,
-  'a_4': '' as readonly string,
-  'a_5': '' as readonly string,
+  'a_1': '' as string,
+  'a_2': '' as string,
+  'a_2': '' as string,
+  'a_3': '' as string,
+  'a_4': '' as string,
+  'a_5': '' as string,
   ...blockErrorType((await import('./b.module.css')).default),
   'c_1': (await import('./c.module.css')).default['c_1'],
   'c_alias': (await import('./c.module.css')).default['c_2'],
-};
+} as const;
 styles['a_4'];
 export default styles;

--- a/examples/1-basic/generated/src/b.module.css.d.ts
+++ b/examples/1-basic/generated/src/b.module.css.d.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 declare const styles = {
-  'b_1': '' as readonly string,
-  'b_2': '' as readonly string,
-};
+  'b_1': '' as string,
+  'b_2': '' as string,
+} as const;
 export default styles;

--- a/examples/1-basic/generated/src/c.module.css.d.ts
+++ b/examples/1-basic/generated/src/c.module.css.d.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 declare const styles = {
-  'c_1': '' as readonly string,
-  'c_2': '' as readonly string,
-};
+  'c_1': '' as string,
+  'c_2': '' as string,
+} as const;
 export default styles;

--- a/examples/3-import-alias/generated/src/a.module.css.d.ts
+++ b/examples/3-import-alias/generated/src/a.module.css.d.ts
@@ -3,5 +3,5 @@ function blockErrorType<T>(val: T): [0] extends [(1 & T)] ? {} : T;
 declare const styles = {
   ...blockErrorType((await import('@/src/b.module.css')).default),
   ...blockErrorType((await import('#src/b.module.css')).default),
-};
+} as const;
 export default styles;

--- a/examples/3-import-alias/generated/src/b.module.css.d.ts
+++ b/examples/3-import-alias/generated/src/b.module.css.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
 declare const styles = {
-  'b_1': '' as readonly string,
-};
+  'b_1': '' as string,
+} as const;
 export default styles;

--- a/packages/codegen/e2e-test/index.test.ts
+++ b/packages/codegen/e2e-test/index.test.ts
@@ -2,7 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { stripVTControlCharacters } from 'node:util';
 import { join } from '@css-modules-kit/core';
 import dedent from 'dedent';
-import { expect, test } from 'vite-plus/test';
+import { describe, expect, test } from 'vite-plus/test';
 import { createIFF } from '../src/test/fixture.js';
 
 const binPath = join(import.meta.dirname, '../bin/cmk.js');
@@ -45,31 +45,31 @@ test('generates .d.ts', async () => {
   expect(cmk.stderr.toString()).toBe('');
   expect(cmk.status).toBe(0);
   expect(await iff.readFile('generated/src/a.module.css.d.ts')).toMatchInlineSnapshot(`
-    "// @ts-nocheck
-    function blockErrorType<T>(val: T): [0] extends [(1 & T)] ? {} : T;
-    declare const styles = {
-      'a1': '' as readonly string,
-      ...blockErrorType((await import('./b.module.css')).default),
-      ...blockErrorType((await import('./unmatched.module.css')).default),
-    };
-    export default styles;
-    "
+  	"// @ts-nocheck
+  	function blockErrorType<T>(val: T): [0] extends [(1 & T)] ? {} : T;
+  	declare const styles = {
+  	  'a1': '' as string,
+  	  ...blockErrorType((await import('./b.module.css')).default),
+  	  ...blockErrorType((await import('./unmatched.module.css')).default),
+  	} as const;
+  	export default styles;
+  	"
   `);
   expect(await iff.readFile('generated/src/b.module.css.d.ts')).toMatchInlineSnapshot(`
-    "// @ts-nocheck
-    declare const styles = {
-      'b1': '' as readonly string,
-    };
-    export default styles;
-    "
+  	"// @ts-nocheck
+  	declare const styles = {
+  	  'b1': '' as string,
+  	} as const;
+  	export default styles;
+  	"
   `);
   expect(await iff.readFile('generated/src/c.module.css.d.ts')).toMatchInlineSnapshot(`
-    "// @ts-nocheck
-    declare const styles = {
-      'c1': '' as readonly string,
-    };
-    export default styles;
-    "
+  	"// @ts-nocheck
+  	declare const styles = {
+  	  'c1': '' as string,
+  	} as const;
+  	export default styles;
+  	"
   `);
 
   // Check if the generated .d.ts passes the type check
@@ -184,34 +184,34 @@ test('generates .d.ts with circular import', async () => {
   expect(cmk.stderr.toString()).toBe('');
   expect(cmk.status).toBe(0);
   expect(await iff.readFile('generated/src/a.module.css.d.ts')).toMatchInlineSnapshot(`
-    "// @ts-nocheck
-    function blockErrorType<T>(val: T): [0] extends [(1 & T)] ? {} : T;
-    declare const styles = {
-      'a1': '' as readonly string,
-      ...blockErrorType((await import('./b.module.css')).default),
-    };
-    export default styles;
-    "
+  	"// @ts-nocheck
+  	function blockErrorType<T>(val: T): [0] extends [(1 & T)] ? {} : T;
+  	declare const styles = {
+  	  'a1': '' as string,
+  	  ...blockErrorType((await import('./b.module.css')).default),
+  	} as const;
+  	export default styles;
+  	"
   `);
   expect(await iff.readFile('generated/src/b.module.css.d.ts')).toMatchInlineSnapshot(`
-    "// @ts-nocheck
-    function blockErrorType<T>(val: T): [0] extends [(1 & T)] ? {} : T;
-    declare const styles = {
-      'b1': '' as readonly string,
-      ...blockErrorType((await import('./a.module.css')).default),
-    };
-    export default styles;
-    "
+  	"// @ts-nocheck
+  	function blockErrorType<T>(val: T): [0] extends [(1 & T)] ? {} : T;
+  	declare const styles = {
+  	  'b1': '' as string,
+  	  ...blockErrorType((await import('./a.module.css')).default),
+  	} as const;
+  	export default styles;
+  	"
   `);
   expect(await iff.readFile('generated/src/c.module.css.d.ts')).toMatchInlineSnapshot(`
-    "// @ts-nocheck
-    function blockErrorType<T>(val: T): [0] extends [(1 & T)] ? {} : T;
-    declare const styles = {
-      'c1': '' as readonly string,
-      ...blockErrorType((await import('./c.module.css')).default),
-    };
-    export default styles;
-    "
+  	"// @ts-nocheck
+  	function blockErrorType<T>(val: T): [0] extends [(1 & T)] ? {} : T;
+  	declare const styles = {
+  	  'c1': '' as string,
+  	  ...blockErrorType((await import('./c.module.css')).default),
+  	} as const;
+  	export default styles;
+  	"
   `);
 
   // Check if the generated .d.ts passes the type check
@@ -219,4 +219,52 @@ test('generates .d.ts with circular import', async () => {
   expect(tsc.error).toBeUndefined();
   expect(tsc.stdout.toString()).toBe('');
   expect(tsc.status).toBe(0);
+});
+
+describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: $namedExports', ({ namedExports }) => {
+  test('tsc reports `Cannot assign to read-only property` on styles.<token>', async () => {
+    const stylesImport = namedExports
+      ? `import * as styles from './a.module.css';`
+      : `import styles from './a.module.css';`;
+    const iff = await createIFF({
+      'src/a.module.css': dedent`
+          @import './b.module.css';
+          @value c_1 from './c.module.css';
+          .a_1 { color: red; }
+        `,
+      'src/b.module.css': `.b_1 { color: red; }`,
+      'src/c.module.css': `@value c_1: red;`,
+      'src/a.ts': dedent`
+          ${stylesImport}
+          // @ts-expect-error -- local token
+          styles.a_1 = '';
+          // @ts-expect-error -- token from all token importer
+          styles.b_1 = '';
+          // @ts-expect-error -- token from named token importer
+          styles.c_1 = '';
+        `,
+      'tsconfig.json': dedent`
+          {
+            "compilerOptions": {
+              "lib": ["ES2015"],
+              "module": "Preserve",
+              "moduleResolution": "bundler",
+              "noEmit": true,
+              "rootDirs": [".", "generated"]
+            },
+            "cmkOptions": { "enabled": true, "namedExports": ${namedExports} }
+          }
+        `,
+    });
+
+    const cmk = spawnSync('node', [binPath], { cwd: iff.rootDir });
+    expect(cmk.error).toBeUndefined();
+    expect(cmk.stderr.toString()).toBe('');
+    expect(cmk.status).toBe(0);
+
+    const tsc = spawnSync('node', [tscPath], { cwd: iff.rootDir });
+    expect(tsc.error).toBeUndefined();
+    expect(tsc.stdout.toString()).toBe('');
+    expect(tsc.status).toBe(0);
+  });
 });

--- a/packages/codegen/src/project.test.ts
+++ b/packages/codegen/src/project.test.ts
@@ -195,12 +195,12 @@ describe('updateFile', () => {
     // New .d.ts file is emitted
     await project.emitDtsFiles();
     expect(await iff.readFile('generated/src/a.module.css.d.ts')).toMatchInlineSnapshot(`
-      "// @ts-nocheck
-      declare const styles = {
-        'a_1': '' as readonly string,
-      };
-      export default styles;
-      "
+    	"// @ts-nocheck
+    	declare const styles = {
+    	  'a_1': '' as string,
+    	} as const;
+    	export default styles;
+    	"
     `);
 
     // New semantic diagnostics are reported
@@ -519,20 +519,20 @@ describe('emitDtsFiles', () => {
     const project = createProject({ project: iff.rootDir });
     await project.emitDtsFiles();
     expect(await iff.readFile('generated/src/a.module.css.d.ts')).toMatchInlineSnapshot(`
-      "// @ts-nocheck
-      declare const styles = {
-        'a1': '' as readonly string,
-      };
-      export default styles;
-      "
+    	"// @ts-nocheck
+    	declare const styles = {
+    	  'a1': '' as string,
+    	} as const;
+    	export default styles;
+    	"
     `);
     expect(await iff.readFile('generated/src/b.module.css.d.ts')).toMatchInlineSnapshot(`
-      "// @ts-nocheck
-      declare const styles = {
-        'b1': '' as readonly string,
-      };
-      export default styles;
-      "
+    	"// @ts-nocheck
+    	declare const styles = {
+    	  'b1': '' as string,
+    	} as const;
+    	export default styles;
+    	"
     `);
   });
   test('does not emit .d.ts files for files not matched by `pattern`', async () => {
@@ -544,12 +544,12 @@ describe('emitDtsFiles', () => {
     const project = createProject({ project: iff.rootDir });
     await project.emitDtsFiles();
     expect(await iff.readFile('generated/src/a.module.css.d.ts')).toMatchInlineSnapshot(`
-      "// @ts-nocheck
-      declare const styles = {
-        'a1': '' as readonly string,
-      };
-      export default styles;
-      "
+    	"// @ts-nocheck
+    	declare const styles = {
+    	  'a1': '' as string,
+    	} as const;
+    	export default styles;
+    	"
     `);
     await expect(access(iff.join('generated/src/a.module.css.d.ts'))).resolves.not.toThrow();
     await expect(access(iff.join('generated/src/b.css.d.ts'))).rejects.toThrow();

--- a/packages/codegen/src/runner.test.ts
+++ b/packages/codegen/src/runner.test.ts
@@ -28,20 +28,20 @@ describe('runCMK', () => {
     });
     await runCMK(fakeParsedArgs({ project: iff.rootDir }), createLoggerSpy());
     expect(await iff.readFile('generated/src/a.module.css.d.ts')).toMatchInlineSnapshot(`
-      "// @ts-nocheck
-      declare const styles = {
-        'a_1': '' as readonly string,
-      };
-      export default styles;
-      "
+    	"// @ts-nocheck
+    	declare const styles = {
+    	  'a_1': '' as string,
+    	} as const;
+    	export default styles;
+    	"
     `);
     expect(await iff.readFile('generated/src/b.module.css.d.ts')).toMatchInlineSnapshot(`
-      "// @ts-nocheck
-      declare const styles = {
-        'b_1': '' as readonly string,
-      };
-      export default styles;
-      "
+    	"// @ts-nocheck
+    	declare const styles = {
+    	  'b_1': '' as string,
+    	} as const;
+    	export default styles;
+    	"
     `);
   });
   test('reports diagnostics if errors are found', async () => {
@@ -130,20 +130,20 @@ describe('runCMKInWatchMode', () => {
     });
     watcher = await runCMKInWatchMode(fakeParsedArgs({ project: iff.rootDir }), createLoggerSpy());
     expect(await iff.readFile('generated/src/a.module.css.d.ts')).toMatchInlineSnapshot(`
-      "// @ts-nocheck
-      declare const styles = {
-        'a_1': '' as readonly string,
-      };
-      export default styles;
-      "
+    	"// @ts-nocheck
+    	declare const styles = {
+    	  'a_1': '' as string,
+    	} as const;
+    	export default styles;
+    	"
     `);
     expect(await iff.readFile('generated/src/b.module.css.d.ts')).toMatchInlineSnapshot(`
-      "// @ts-nocheck
-      declare const styles = {
-        'b_1': '' as readonly string,
-      };
-      export default styles;
-      "
+    	"// @ts-nocheck
+    	declare const styles = {
+    	  'b_1': '' as string,
+    	} as const;
+    	export default styles;
+    	"
     `);
   });
   test('reports diagnostics if errors are found', async () => {

--- a/packages/core/src/dts-generator.test.ts
+++ b/packages/core/src/dts-generator.test.ts
@@ -33,7 +33,7 @@ describe('generates an empty .d.ts file when the CSS module has no tokens', () =
     	=== generated ===
     	// @ts-nocheck
     	declare const styles = {
-    	};
+    	} as const;
     	export default styles;
     	"
     `);
@@ -70,13 +70,13 @@ describe('creates an entry for each local token declaration', () => {
     	=== generated ===
     	// @ts-nocheck
     	declare const styles = {
-    	  'a_1': '' as readonly string,
+    	  'a_1': '' as string,
     	   ^^^ mapping[0]
-    	  'a_2': '' as readonly string,
+    	  'a_2': '' as string,
     	   ^^^ mapping[1]
-    	  'a_2': '' as readonly string,
+    	  'a_2': '' as string,
     	   ^^^ mapping[2]
-    	};
+    	} as const;
     	export default styles;
     	"
     `);
@@ -136,7 +136,7 @@ describe('re-exports tokens from an all token importer', () => {
     	                                  ^^^^^^^^^^^^^^^^ mapping[1]
     	  ...blockErrorType((await import('./c.module.css')).default),
     	                                  ^^^^^^^^^^^^^^^^ mapping[2]
-    	};
+    	} as const;
     	export default styles;
     	"
     `);
@@ -208,7 +208,7 @@ describe('re-exports tokens from a named token importer', () => {
     	                       ^^^^^^^^^^^^^^^^ mapping[7]
     	   ^^^ mapping[6]
     	  ^^^^^ linkedCodeMapping[3]
-    	};
+    	} as const;
     	export default styles;
     	"
     `);
@@ -278,11 +278,11 @@ describe('creates a reference for a token reference', () => {
     	=== generated ===
     	// @ts-nocheck
     	declare const styles = {
-    	  'a_1': '' as readonly string,
+    	  'a_1': '' as string,
     	   ^^^ mapping[0]
-    	  'a_2': '' as readonly string,
+    	  'a_2': '' as string,
     	   ^^^ mapping[1]
-    	};
+    	} as const;
     	styles['a_1'];
     	        ^^^ mapping[2]
     	export default styles;
@@ -332,7 +332,7 @@ describe('omits importers whose specifier is a URL', () => {
     	=== generated ===
     	// @ts-nocheck
     	declare const styles = {
-    	};
+    	} as const;
     	export default styles;
     	"
     `);
@@ -367,7 +367,7 @@ describe('omits tokens whose name fails validateTokenName', () => {
     	=== generated ===
     	// @ts-nocheck
     	declare const styles = {
-    	};
+    	} as const;
     	export default styles;
     	"
     `);

--- a/packages/core/src/dts-generator.ts
+++ b/packages/core/src/dts-generator.ts
@@ -83,10 +83,10 @@ export function generateDts(cssModule: CSSModule, options: GenerateDtsOptions): 
        * // generated/src/a.module.css.d.ts
        * // @ts-nocheck
        * declare const styles = {
-       *   a_1: '' as readonly string,
+       *   a_1: '' as string,
        *   ...(await import('./unresolved.module.css')).default,
        *   ...(await import('./unmatched.css')).default,
-       * };
+       * } as const;
        * ```
        *
        * Even if `./unresolved.module.css` or `./unmatched.css` does not exist, the same type definitions are
@@ -359,20 +359,20 @@ function generateDefaultExportDts(
      *
      * a.module.css.d.ts:
      * 1 | declare const styles = {
-     * 2 |   'a_1': '' as readonly string,
+     * 2 |   'a_1': '' as string,
      *   |    ^ mapping.generatedOffsets[0]
      *   |
-     * 3 |   'a_2': '' as readonly string,
+     * 3 |   'a_2': '' as string,
      *   |    ^ mapping.generatedOffsets[1]
      *   |
-     * 4 | };
+     * 4 | } as const;
      */
 
     text += `  '`;
     mapping.sourceOffsets.push(token.loc.start.offset);
     mapping.lengths.push(token.name.length);
     mapping.generatedOffsets.push(text.length);
-    text += `${token.name}': '' as readonly string,\n`;
+    text += `${token.name}': '' as string,\n`;
   }
   for (const tokenImporter of tokenImporters) {
     if (tokenImporter.type === 'all') {
@@ -394,7 +394,7 @@ function generateDefaultExportDts(
        * 3 |   ...blockErrorType((await import('./c.module.css')).default),
        *   |                                   ^ mapping.generatedOffsets[1]
        *   |
-       * 4 | };
+       * 4 | } as const;
        *
        * NOTE: Not only the specifier but also the surrounding quotes are included in the mapping.
        */
@@ -439,7 +439,7 @@ function generateDefaultExportDts(
        *   |   ^^ mapping.generatedOffsets[3]
        *   |   ^ linkedCodeMapping.sourceOffsets[2]
        *   |
-       * 5 | };
+       * 5 | } as const;
        *
        * NOTE: Not only the specifier but also the surrounding quotes are included in the mapping.
        */
@@ -473,7 +473,7 @@ function generateDefaultExportDts(
       });
     }
   }
-  text += `};\n`;
+  text += `} as const;\n`;
 
   /**
    * The mapping is created as follows:


### PR DESCRIPTION
## Summary

The default-export `.d.ts` was emitting each token as `'<name>': '' as readonly string,`. Since the `readonly` modifier is only valid on array/tuple types, this was actually a TypeScript syntax error that was being silently suppressed by `@ts-nocheck`. As a result, the intended readonly behavior on `styles` was not in effect, and writes like `styles.foo = 'x'` were accepted by `tsc`.

## Fix

In `packages/core/src/dts-generator.ts`, change the generated output as follows:

- Per token: `'<name>': '' as readonly string,` → `'<name>': '' as string,`
- End of the object literal: `};` → `} as const;`

This makes `typeof styles` evaluate to `Readonly<{ ... }>`, so `styles.foo = '...'` is now a type error. The `'' as string` cast widens the literal `''` to `string` so each generated property keeps the `string` type.

## Regression test

Add a parametrized test to `packages/codegen/e2e-test/index.test.ts`:

- `describe.each([{ namedExports: false }, { namedExports: true }])` covers both default-export and named-export modes.
- Verifies that `styles.<token> = ''` is a `tsc` error for all three token-import paths (local / spread via `@import` / named import via `@value ... from`) by running real `tsc` with `// @ts-expect-error` annotations.

In named-export mode the writes are already rejected by ES module semantics, so that row passes today. The default-export row only starts passing once `as const` is added.

## Test plan

- [x] `vp test` passes
- [x] `vp check` passes
- [x] Sanity check: temporarily reverting `} as const;` back to `};` makes the new test's `namedExports: false` row fail with `Unused '@ts-expect-error' directive`, confirming the regression direction.