### PR TITLE
test(ts-plugin): add e2e test for styles auto-import with import alias

### DIFF
--- a/packages/ts-plugin/e2e-test/completion.test.ts
+++ b/packages/ts-plugin/e2e-test/completion.test.ts
@@ -120,6 +120,33 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
         },
       ]);
     });
+
+    test('suggests the styles entry with an import-alias source', async () => {
+      const { iff, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({
+          compilerOptions: { paths: { '@/*': ['./*'] } },
+          cmkOptions: { namedExports },
+        }),
+        'index.ts': `styles;`,
+        'a.module.css': '',
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['index.ts'] }] });
+      await tsserver.sendConfigure({
+        preferences: {
+          includeCompletionsForModuleExports: true,
+          importModuleSpecifierPreference: 'non-relative',
+        },
+      });
+
+      const res = await tsserver.sendCompletionInfo({
+        file: iff.paths['index.ts'],
+        ...getRange('index.ts', 'styles').end,
+      });
+
+      expect(
+        normalizeCompletionEntry(res.body?.entries.filter((entry) => entry.name === 'styles') ?? []),
+      ).toStrictEqual(normalizeCompletionEntry([{ name: 'styles', sortText: '16', source: '@/a.module.css' }]));
+    });
   });
 
   describe('className attribute snippet', () => {


### PR DESCRIPTION
## Summary
- Add an e2e test that asserts the `styles` completion suggestion's `source` is the alias-form specifier (e.g. `@/a.module.css`) when an import alias is configured via tsconfig `paths`.
- The current implementation already supports auto-import using import aliases, but there was no test for it, so future changes could regress this behavior unnoticed.
- The test is placed inside the existing `describe.each`, so it runs for both `namedExports: false` and `namedExports: true`.

## Test plan
- [x] `vp test --project e2e packages/ts-plugin/e2e-test/completion.test.ts` passes
- [x] `vp check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)