### PR TITLE
fix(vscode, ts-plugin): support file rename from a CSS module `@import` / `@value ... from` specifier

### DIFF
--- a/.changeset/file-rename-from-css-import-specifier.md
+++ b/.changeset/file-rename-from-css-import-specifier.md
@@ -1,0 +1,10 @@
+---
+'css-modules-kit-vscode': patch
+'@css-modules-kit/ts-plugin': patch
+---
+
+fix(vscode, ts-plugin): support file rename from a CSS module `@import` / `@value ... from` specifier
+
+Renaming a CSS module via the import specifier in VS Code (e.g. invoking Rename Symbol on `b.module.css` inside `@import './b.module.css';`) now performs a real file rename and updates every importer of the renamed file. Previously the located text span was blindly replaced with the user's input, which dropped the path prefix (`'./b.module.css'` became `'bb.module.css'`) and left the file on disk unchanged.
+
+ts-plugin exposes a new internal protocol handler `_css-modules-kit:getEditsForFileRename` that wraps the standard tsserver `getEditsForFileRename` so the request can be reached through `typescript.tsserverRequest`.

--- a/packages/ts-plugin/e2e-test/rename-file.test.ts
+++ b/packages/ts-plugin/e2e-test/rename-file.test.ts
@@ -6,6 +6,27 @@ import { formatPath, launchTsserver } from './test-util/tsserver.js';
 const tsserver = launchTsserver();
 
 describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: $namedExports', ({ namedExports }) => {
+  test('reports `fileToRename` so editors can initiate a file rename from a CSS specifier', async () => {
+    const { iff, getLoc } = await setupFixture({
+      'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+      'a.module.css': `@import './b.module.css';`,
+      'b.module.css': '',
+    });
+    await tsserver.sendConfigure({ preferences: { allowRenameOfImportPath: true } });
+    await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+    const res = await tsserver.sendRename({
+      file: iff.paths['a.module.css'],
+      ...getLoc('a.module.css', 'b.module.css'),
+    });
+
+    expect(res.body?.info).toMatchObject({
+      canRename: true,
+      kind: 'module',
+      fileToRename: formatPath(iff.paths['b.module.css']),
+    });
+  });
+
   describe('rewrites the import specifier when a CSS module is renamed', () => {
     test('from `import ... from` in TS', async () => {
       const { iff, getRange } = await setupFixture({

--- a/packages/ts-plugin/e2e-test/rename-file.test.ts
+++ b/packages/ts-plugin/e2e-test/rename-file.test.ts
@@ -6,24 +6,47 @@ import { formatPath, launchTsserver } from './test-util/tsserver.js';
 const tsserver = launchTsserver();
 
 describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: $namedExports', ({ namedExports }) => {
-  test('reports `fileToRename` so editors can initiate a file rename from a CSS specifier', async () => {
-    const { iff, getLoc } = await setupFixture({
-      'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
-      'a.module.css': `@import './b.module.css';`,
-      'b.module.css': '',
-    });
-    await tsserver.sendConfigure({ preferences: { allowRenameOfImportPath: true } });
-    await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+  describe('reports `fileToRename` so editors can initiate a file rename from a CSS specifier', () => {
+    test('from all token importer', async () => {
+      const { iff, getLoc } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': `@import './b.module.css';`,
+        'b.module.css': '',
+      });
+      await tsserver.sendConfigure({ preferences: { allowRenameOfImportPath: true } });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
 
-    const res = await tsserver.sendRename({
-      file: iff.paths['a.module.css'],
-      ...getLoc('a.module.css', 'b.module.css'),
+      const res = await tsserver.sendRename({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'b.module.css'),
+      });
+
+      expect(res.body?.info).toMatchObject({
+        canRename: true,
+        kind: 'module',
+        fileToRename: formatPath(iff.paths['b.module.css']),
+      });
     });
 
-    expect(res.body?.info).toMatchObject({
-      canRename: true,
-      kind: 'module',
-      fileToRename: formatPath(iff.paths['b.module.css']),
+    test('from named token importer', async () => {
+      const { iff, getLoc } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': `@value b_1 from './b.module.css';`,
+        'b.module.css': `@value b_1: red;`,
+      });
+      await tsserver.sendConfigure({ preferences: { allowRenameOfImportPath: true } });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendRename({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'b.module.css'),
+      });
+
+      expect(res.body?.info).toMatchObject({
+        canRename: true,
+        kind: 'module',
+        fileToRename: formatPath(iff.paths['b.module.css']),
+      });
     });
   });
 
@@ -49,7 +72,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       ]);
     });
 
-    test('from `@import` in CSS', async () => {
+    test('from all token importer', async () => {
       const { iff, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@import './b.module.css';`,
@@ -70,7 +93,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       ]);
     });
 
-    test('from `@value ... from` in CSS', async () => {
+    test('from named token importer', async () => {
       const { iff, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': `@value b_1 from './b.module.css';`,

--- a/packages/ts-plugin/src/index.cts
+++ b/packages/ts-plugin/src/index.cts
@@ -7,6 +7,7 @@ import type ts from 'typescript';
 import { createCSSLanguagePlugin } from './language-plugin.js';
 import { proxyLanguageService } from './language-service/proxy.js';
 import { createDocumentLinkHandler } from './protocol-handler/documentLink.js';
+import { createGetEditsForFileRenameHandler } from './protocol-handler/getEditsForFileRename.js';
 import { createRenameHandler } from './protocol-handler/rename.js';
 import { createRenameInfoHandler } from './protocol-handler/renameInfo.js';
 import { CustomSourceMap } from './source-map.js';
@@ -97,6 +98,10 @@ const plugin = createLanguageServicePlugin((ts, info) => {
           info.session.addProtocolHandler(
             '_css-modules-kit:renameInfo',
             createRenameInfoHandler(info.project.projectService),
+          );
+          info.session.addProtocolHandler(
+            '_css-modules-kit:getEditsForFileRename',
+            createGetEditsForFileRenameHandler(info.project.projectService),
           );
           info.session.addProtocolHandler(
             '_css-modules-kit:documentLink',

--- a/packages/ts-plugin/src/protocol-handler/getEditsForFileRename.ts
+++ b/packages/ts-plugin/src/protocol-handler/getEditsForFileRename.ts
@@ -1,0 +1,19 @@
+import ts from 'typescript';
+import type {
+  CSSModulesKitGetEditsForFileRenameHandlerResponse,
+  CSSModulesKitGetEditsForFileRenameRequest,
+} from '../type.js';
+import { getConfiguredProjectForFile } from '../util.js';
+
+export function createGetEditsForFileRenameHandler(projectService: ts.server.ProjectService) {
+  return (request: CSSModulesKitGetEditsForFileRenameRequest): CSSModulesKitGetEditsForFileRenameHandlerResponse => {
+    const { oldFilePath, newFilePath } = request.arguments;
+    const project = getConfiguredProjectForFile(projectService, oldFilePath);
+    if (!project) return {};
+    const languageService = project.getLanguageService();
+    const formatOptions = projectService.getFormatCodeOptions(ts.server.toNormalizedPath(oldFilePath));
+    const preference = projectService.getPreferences(ts.server.toNormalizedPath(oldFilePath));
+    const result = languageService.getEditsForFileRename(oldFilePath, newFilePath, formatOptions, preference);
+    return { response: { result } };
+  };
+}

--- a/packages/ts-plugin/src/type.ts
+++ b/packages/ts-plugin/src/type.ts
@@ -24,6 +24,18 @@ export interface CSSModulesKitRenameInfoResponse extends ts.server.protocol.Resp
   readonly body: CSSModulesKitRenameInfoHandlerResponse['response'];
 }
 
+export interface CSSModulesKitGetEditsForFileRenameRequest extends ts.server.protocol.Request {
+  command: '_css-modules-kit:getEditsForFileRename';
+  arguments: { oldFilePath: string; newFilePath: string };
+}
+export interface CSSModulesKitGetEditsForFileRenameHandlerResponse extends ts.server.HandlerResponse {
+  response?: { result: ReturnType<ts.LanguageService['getEditsForFileRename']> };
+}
+export interface CSSModulesKitGetEditsForFileRenameResponse extends ts.server.protocol.Response {
+  command: '_css-modules-kit:getEditsForFileRename';
+  readonly body: CSSModulesKitGetEditsForFileRenameHandlerResponse['response'];
+}
+
 export interface DocumentLink {
   fileName: string;
   textSpan: ts.TextSpan;
@@ -51,6 +63,12 @@ declare module 'typescript' {
       addProtocolHandler(
         command: '_css-modules-kit:renameInfo',
         handler: (request: CSSModulesKitRenameInfoRequest) => CSSModulesKitRenameInfoHandlerResponse,
+      ): void;
+      addProtocolHandler(
+        command: '_css-modules-kit:getEditsForFileRename',
+        handler: (
+          request: CSSModulesKitGetEditsForFileRenameRequest,
+        ) => CSSModulesKitGetEditsForFileRenameHandlerResponse,
       ): void;
       addProtocolHandler(
         command: '_css-modules-kit:documentLink',

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -12,28 +12,24 @@ import type {
 } from '@css-modules-kit/ts-plugin/type';
 import * as vscode from 'vscode';
 
-async function buildFileRenameEdit(oldFilePath: string, newName: string): Promise<vscode.WorkspaceEdit> {
+async function buildFileRenameEdit(oldFilePath: string, newName: string): Promise<vscode.WorkspaceEdit | undefined> {
   const newFilePath = join(dirname(oldFilePath), newName);
-  const edit = new vscode.WorkspaceEdit();
-  edit.renameFile(vscode.Uri.file(oldFilePath), vscode.Uri.file(newFilePath));
-
-  // Wrap tsserver's `getEditsForFileRename` in a custom protocol handler — `typescript.tsserverRequest`
-  // silently drops built-in commands like `getEditsForFileRename`, so the same "request forwarding" trick
-  // used for rename / renameInfo is required to reach it.
   const editsRes = await vscode.commands.executeCommand<CSSModulesKitGetEditsForFileRenameResponse>(
     'typescript.tsserverRequest',
     '_css-modules-kit:getEditsForFileRename',
     { oldFilePath, newFilePath } satisfies CSSModulesKitGetEditsForFileRenameRequest['arguments'],
   );
-  if (editsRes.success && editsRes.body?.result) {
-    for (const fileEdit of editsRes.body.result) {
-      // oxlint-disable-next-line no-await-in-loop
-      const targetDoc = await vscode.workspace.openTextDocument(fileEdit.fileName);
-      for (const change of fileEdit.textChanges) {
-        const start = targetDoc.positionAt(change.span.start);
-        const end = targetDoc.positionAt(change.span.start + change.span.length);
-        edit.replace(vscode.Uri.file(fileEdit.fileName), new vscode.Range(start, end), change.newText);
-      }
+  if (!editsRes.success || !editsRes.body?.result) return undefined;
+
+  const edit = new vscode.WorkspaceEdit();
+  edit.renameFile(vscode.Uri.file(oldFilePath), vscode.Uri.file(newFilePath));
+  for (const fileEdit of editsRes.body.result) {
+    // oxlint-disable-next-line no-await-in-loop
+    const targetDoc = await vscode.workspace.openTextDocument(fileEdit.fileName);
+    for (const change of fileEdit.textChanges) {
+      const start = targetDoc.positionAt(change.span.start);
+      const end = targetDoc.positionAt(change.span.start + change.span.length);
+      edit.replace(vscode.Uri.file(fileEdit.fileName), new vscode.Range(start, end), change.newText);
     }
   }
   return edit;

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -1,12 +1,43 @@
+// oxlint-disable-next-line no-restricted-imports
+import { dirname, join } from 'node:path';
 import type {
   CSSModulesKitDocumentLinkRequest,
   CSSModulesKitDocumentLinkResponse,
+  CSSModulesKitGetEditsForFileRenameRequest,
+  CSSModulesKitGetEditsForFileRenameResponse,
   CSSModulesKitRenameInfoRequest,
   CSSModulesKitRenameInfoResponse,
   CSSModulesKitRenameRequest,
   CSSModulesKitRenameResponse,
 } from '@css-modules-kit/ts-plugin/type';
 import * as vscode from 'vscode';
+
+async function buildFileRenameEdit(oldFilePath: string, newName: string): Promise<vscode.WorkspaceEdit> {
+  const newFilePath = join(dirname(oldFilePath), newName);
+  const edit = new vscode.WorkspaceEdit();
+  edit.renameFile(vscode.Uri.file(oldFilePath), vscode.Uri.file(newFilePath));
+
+  // Wrap tsserver's `getEditsForFileRename` in a custom protocol handler — `typescript.tsserverRequest`
+  // silently drops built-in commands like `getEditsForFileRename`, so the same "request forwarding" trick
+  // used for rename / renameInfo is required to reach it.
+  const editsRes = await vscode.commands.executeCommand<CSSModulesKitGetEditsForFileRenameResponse>(
+    'typescript.tsserverRequest',
+    '_css-modules-kit:getEditsForFileRename',
+    { oldFilePath, newFilePath } satisfies CSSModulesKitGetEditsForFileRenameRequest['arguments'],
+  );
+  if (editsRes.success && editsRes.body?.result) {
+    for (const fileEdit of editsRes.body.result) {
+      // oxlint-disable-next-line no-await-in-loop
+      const targetDoc = await vscode.workspace.openTextDocument(fileEdit.fileName);
+      for (const change of fileEdit.textChanges) {
+        const start = targetDoc.positionAt(change.span.start);
+        const end = targetDoc.positionAt(change.span.start + change.span.length);
+        edit.replace(vscode.Uri.file(fileEdit.fileName), new vscode.Range(start, end), change.newText);
+      }
+    }
+  }
+  return edit;
+}
 
 export function activate(context: vscode.ExtensionContext) {
   console.log('[css-modules-kit-vscode] Activated');
@@ -27,6 +58,22 @@ export function activate(context: vscode.ExtensionContext) {
       { scheme: 'file', language: 'css' },
       {
         async provideRenameEdits(document, position, newName, _token) {
+          // Detect a file rename (renaming a CSS module via its `@import` / `@value ... from` specifier).
+          // When the language service reports `fileToRename`, the editor must perform a file rename plus a
+          // `getEditsForFileRename`-driven import update.
+          const infoRes = await vscode.commands.executeCommand<CSSModulesKitRenameInfoResponse>(
+            'typescript.tsserverRequest',
+            '_css-modules-kit:renameInfo',
+            {
+              fileName: document.fileName,
+              position: document.offsetAt(position),
+            } satisfies CSSModulesKitRenameInfoRequest['arguments'],
+          );
+          const info = infoRes.success ? infoRes.body?.result : undefined;
+          if (info?.canRename && info.fileToRename) {
+            return buildFileRenameEdit(info.fileToRename, newName);
+          }
+
           const res = await vscode.commands.executeCommand<CSSModulesKitRenameResponse>(
             'typescript.tsserverRequest',
             '_css-modules-kit:rename',

--- a/packages/vscode/vscode-test/request-forwarding-to-tsserver.test.ts
+++ b/packages/vscode/vscode-test/request-forwarding-to-tsserver.test.ts
@@ -158,8 +158,6 @@ describe('Go to Definition for specifiers with import alias', () => {
 
 describe('Renaming a CSS module via import specifier', () => {
   it('renames the file and rewrites the import while preserving the `./` prefix', async () => {
-    // Create a fresh, isolated fixture per run so the on-disk file rename does not pollute the
-    // workspace fixture committed under `examples/`.
     const iff = await createFixture({
       'tsconfig.json': JSON.stringify({ cmkOptions: { enabled: true } }),
       'd.module.css': `@import './e.module.css';\n`,

--- a/packages/vscode/vscode-test/request-forwarding-to-tsserver.test.ts
+++ b/packages/vscode/vscode-test/request-forwarding-to-tsserver.test.ts
@@ -14,7 +14,7 @@
 import * as assert from 'node:assert/strict';
 import { before, describe, it } from 'mocha';
 import * as vscode from 'vscode';
-import { toObject } from './util.js';
+import { createFixture, toObject } from './util.js';
 
 const workspaceRoot = vscode.workspace.workspaceFolders![0]!.uri;
 const aModuleCSS1Path = vscode.Uri.joinPath(workspaceRoot, 'src/dir-1/a.module.css');
@@ -152,6 +152,42 @@ describe('Go to Definition for specifiers with import alias', () => {
     assert.deepEqual(
       toObject(links[1]!.range),
       toObject(new vscode.Range(2, 9, 2, 33)), // `@/src/dir-1/b.module.css`
+    );
+  });
+});
+
+describe('Renaming a CSS module via import specifier', () => {
+  it('renames the file and rewrites the import while preserving the `./` prefix', async () => {
+    // Create a fresh, isolated fixture per run so the on-disk file rename does not pollute the
+    // workspace fixture committed under `examples/`.
+    const iff = await createFixture({
+      'tsconfig.json': JSON.stringify({ cmkOptions: { enabled: true } }),
+      'd.module.css': `@import './e.module.css';\n`,
+      'e.module.css': `.e_1 { color: red; }\n`,
+    });
+    const dModuleCSSPath = vscode.Uri.file(iff.paths['d.module.css']);
+    const renamedEModuleCSSPath = vscode.Uri.file(iff.join('ee.module.css'));
+
+    const dModuleCSSDocument = await vscode.workspace.openTextDocument(dModuleCSSPath);
+    // Cursor on `e` in `@import './e.module.css';`
+    const position = new vscode.Position(0, 11);
+
+    const workspaceEdit = await vscode.commands.executeCommand<vscode.WorkspaceEdit>(
+      'vscode.executeDocumentRenameProvider',
+      dModuleCSSPath,
+      position,
+      'ee.module.css',
+    );
+    const success = await vscode.workspace.applyEdit(workspaceEdit);
+    assert.ok(success);
+
+    // The CSS file itself should have been renamed.
+    await vscode.workspace.fs.stat(renamedEModuleCSSPath);
+
+    // The `@import` line should keep its `./` prefix and only swap the basename.
+    assert.ok(
+      dModuleCSSDocument.getText().includes(`@import './ee.module.css';`),
+      `Expected import to preserve the './' prefix, got:\n${dModuleCSSDocument.getText()}`,
     );
   });
 });

--- a/packages/vscode/vscode-test/util.ts
+++ b/packages/vscode/vscode-test/util.ts
@@ -1,5 +1,16 @@
 import { AssertionError } from 'node:assert';
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+// oxlint-disable-next-line no-restricted-imports
+import { join } from 'node:path';
 import { setTimeout } from 'node:timers/promises';
+import { defineIFFCreator } from '@mizdra/inline-fixture-files';
+
+const fixtureRoot = join(tmpdir(), 'css-modules-kit-vscode-test');
+export const createFixture = defineIFFCreator({
+  generateRootDir: () => join(fixtureRoot, randomUUID()),
+  unixStylePath: true,
+});
 
 export function toObject<T>(value: T): T {
   return JSON.parse(JSON.stringify(value));


### PR DESCRIPTION
## Summary

Fixes a bug where invoking VS Code's Rename Symbol on the specifier of `@import './b.module.css';` or `@value ... from './b.module.css';` in CSS Modules silently performed a wrong text replacement instead of the file rename + cross-importer update flow that TypeScript performs for module specifiers.

The previous behavior was:

- The CSS file itself was not renamed and remained on disk.
- `@import './b.module.css';` became `@import 'bb.module.css';`, dropping the `./` prefix.
- Imports in other files were not updated.

https://github.com/user-attachments/assets/2fb8ed7f-d441-4ed6-b130-9c55e307c336


## Fix

Update the VS Code extension's `provideRenameEdits` as follows:

1. Inspect `getRenameInfo`'s `fileToRename` to detect a file rename.
2. For a file rename, build a `WorkspaceEdit` that combines `WorkspaceEdit.renameFile(oldUri, newUri)` with the text edits returned by `getEditsForFileRename`.
3. Otherwise fall back to the existing symbol rename path.

`typescript.tsserverRequest` silently drops built-in commands, so a new custom protocol handler `_css-modules-kit:getEditsForFileRename` is added on the ts-plugin side to wrap the standard `getEditsForFileRename` (the same "Request Forwarding to tsserver" pattern already used for `rename` / `renameInfo`).

## Test plan

- [x] ts-plugin e2e: pin that `info.fileToRename` is returned for a relative-path specifier.
- [x] vscode-extension e2e: build a self-contained fixture in tmpdir via `createIFF` and assert that renaming via `@import './e.module.css';` becomes `'./ee.module.css';` (the `./` prefix is preserved) and the file is also renamed on disk.
- [x] All existing vscode-test cases (token rename / Go to Definition) still pass.
- [x] `vp test` (376 passed)
- [x] `vp check` (lint / format / type all pass)

https://github.com/user-attachments/assets/fc3a987c-4299-4611-8444-343d3b87eea4


🤖 Generated with [Claude Code](https://claude.com/claude-code)