### PR TITLE
refactor(core, codegen): do not emit token reference statements in codegen .d.ts files

### DIFF
--- a/.changeset/codegen-omit-token-references.md
+++ b/.changeset/codegen-omit-token-references.md
@@ -1,0 +1,8 @@
+---
+'@css-modules-kit/codegen': patch
+'@css-modules-kit/core': patch
+---
+
+refactor(core, codegen): do not emit token reference statements in generated `.d.ts` files
+
+Statements like `styles['a_1'];` and `__self['a_1'];` (emitted for `animation-name` references to `@keyframes`) used to appear in the `.d.ts` files written by codegen. These statements exist solely to wire up editor language features such as Go to Definition, Find All References, and Rename, and are not needed at compile time. The visible types exported by these files are unchanged, but codegen output is no longer cluttered with statements that look meaningless to a reader of the type definition file. The statements are still emitted by the TS plugin, where the language features are actually served.

--- a/examples/1-basic/generated/src/a.module.css.d.ts
+++ b/examples/1-basic/generated/src/a.module.css.d.ts
@@ -11,5 +11,4 @@ declare const styles = {
   'c_1': (await import('./c.module.css')).default['c_1'],
   'c_alias': (await import('./c.module.css')).default['c_2'],
 } as const;
-styles['a_4'];
 export default styles;

--- a/packages/core/src/dts-generator.test.ts
+++ b/packages/core/src/dts-generator.test.ts
@@ -261,13 +261,63 @@ describe('re-exports tokens from a named token importer', () => {
   });
 });
 
-describe('creates a reference for a token reference', () => {
+describe('omits token reference statements when forTsPlugin is false', () => {
   const source = dedent`
     @keyframes a_1 {}
     .a_2 { animation-name: a_1; }
   `;
   test('default export', async () => {
     expect(await run(source, defaultExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+    	@keyframes a_1 {}
+    	           ^^^ mapping[0]
+    	.a_2 { animation-name: a_1; }
+    	 ^^^ mapping[1]
+
+    	=== generated ===
+    	// @ts-nocheck
+    	declare const styles = {
+    	  'a_1': '' as string,
+    	   ^^^ mapping[0]
+    	  'a_2': '' as string,
+    	   ^^^ mapping[1]
+    	} as const;
+    	export default styles;
+    	"
+    `);
+  });
+  test('named export', async () => {
+    expect(await run(source, namedExportOptions)).toMatchInlineSnapshot(`
+    	"=== source ===
+    	@keyframes a_1 {}
+    	           ^^^ mapping[0]
+    	.a_2 { animation-name: a_1; }
+    	 ^^^ mapping[1]
+
+    	=== generated ===
+    	// @ts-nocheck
+    	var _token_0: string;
+    	    ^^^^^^^^ mapping[0]
+    	export { _token_0 as 'a_1' };
+    	                     ^^^^^ linkedCodeMapping[0]
+    	         ^^^^^^^^ linkedCodeMapping[0]
+    	var _token_1: string;
+    	    ^^^^^^^^ mapping[1]
+    	export { _token_1 as 'a_2' };
+    	                     ^^^^^ linkedCodeMapping[1]
+    	         ^^^^^^^^ linkedCodeMapping[1]
+    	"
+    `);
+  });
+});
+
+describe('emits token reference statements when forTsPlugin is true', () => {
+  const source = dedent`
+    @keyframes a_1 {}
+    .a_2 { animation-name: a_1; }
+  `;
+  test('default export', async () => {
+    expect(await run(source, { ...defaultExportOptions, forTsPlugin: true })).toMatchInlineSnapshot(`
     	"=== source ===
     	@keyframes a_1 {}
     	           ^^^ mapping[0]
@@ -290,7 +340,7 @@ describe('creates a reference for a token reference', () => {
     `);
   });
   test('named export', async () => {
-    expect(await run(source, namedExportOptions)).toMatchInlineSnapshot(`
+    expect(await run(source, { ...namedExportOptions, forTsPlugin: true })).toMatchInlineSnapshot(`
     	"=== source ===
     	@keyframes a_1 {}
     	           ^^^ mapping[0]
@@ -313,6 +363,8 @@ describe('creates a reference for a token reference', () => {
     	declare const __self: typeof import('./a.module.css');
     	__self['a_1'];
     	        ^^^ mapping[2]
+    	declare const styles: {};
+    	export default styles;
     	"
     `);
   });

--- a/packages/core/src/dts-generator.ts
+++ b/packages/core/src/dts-generator.ts
@@ -107,7 +107,7 @@ export function generateDts(cssModule: CSSModule, options: GenerateDtsOptions): 
   if (options.namedExports) {
     return generateNamedExportsDts(cssModule.fileName, localTokens, tokenImporters, tokenReferences, options);
   } else {
-    return generateDefaultExportDts(localTokens, tokenImporters, tokenReferences);
+    return generateDefaultExportDts(localTokens, tokenImporters, tokenReferences, options);
   }
 }
 
@@ -293,7 +293,7 @@ function generateNamedExportsDts(
    * 2 | __self['a_1'];
    *   |             ^ mapping.generatedOffsets[0]
    */
-  if (tokenReferences.length > 0) {
+  if (options.forTsPlugin && tokenReferences.length > 0) {
     text += `declare const __self: typeof import('./${basename(fileName)}');\n`;
     for (const ref of tokenReferences) {
       text += `__self['`;
@@ -316,6 +316,7 @@ function generateDefaultExportDts(
   localTokens: Token[],
   tokenImporters: TokenImporter[],
   tokenReferences: TokenReference[],
+  options: GenerateDtsOptions,
 ): {
   text: string;
   mapping: CodeMapping;
@@ -486,12 +487,14 @@ function generateDefaultExportDts(
    * 1 | styles['a_1'];
    *   |         ^ mapping.generatedOffsets[0]
    */
-  for (const ref of tokenReferences) {
-    text += `${STYLES_EXPORT_NAME}['`;
-    mapping.sourceOffsets.push(ref.loc.start.offset);
-    mapping.lengths.push(ref.name.length);
-    mapping.generatedOffsets.push(text.length);
-    text += `${ref.name}'];\n`;
+  if (options.forTsPlugin) {
+    for (const ref of tokenReferences) {
+      text += `${STYLES_EXPORT_NAME}['`;
+      mapping.sourceOffsets.push(ref.loc.start.offset);
+      mapping.lengths.push(ref.name.length);
+      mapping.generatedOffsets.push(text.length);
+      text += `${ref.name}'];\n`;
+    }
   }
   text += `export default ${STYLES_EXPORT_NAME};\n`;
   return { text, mapping, linkedCodeMapping };


### PR DESCRIPTION
## Summary

Stop emitting token reference statements (`styles['a_1'];` / `__self['a_1'];`) in the `.d.ts` files written by codegen. These statements exist solely to wire up editor language features in ts-plugin (Go to Definition, Find All References, Rename) and are not needed by the TypeScript compiler, so to a user reading the generated type definition they look like meaningless noise. The visible types exported by these files are unchanged, so there is no observable behavior change for end users — this is a cleanup of the codegen output. The existing `forTsPlugin` option on `generateDts` is now used to gate both the default-export and named-export forms; ts-plugin keeps emitting the statements as before.

## Changes

- `packages/core/src/dts-generator.ts`: Gate the token reference output blocks in both the default-export and named-export forms on `options.forTsPlugin`. Pass `options` through to `generateDefaultExportDts`.
- `packages/core/src/dts-generator.test.ts`: Add a `describe` block verifying that no reference statements are emitted when `forTsPlugin` is `false`, and a separate `describe` block verifying that they are emitted when `forTsPlugin` is `true`.
- `examples/1-basic/generated/src/a.module.css.d.ts`: Regenerated; `styles['a_4'];` is removed (1 line).
- `.changeset/codegen-omit-token-references.md`: `patch` for both core and codegen so the cleanup shows up in the release notes.

## Test plan

- [x] `vp test --project unit packages/core/src/dts-generator.test.ts` passes
- [x] `vp test` (full suite) passes
- [x] `vp check` / `vp run build` pass
- [ ] (optional) Verify in VSCode via ts-plugin that Go to Definition / Find All References / Rename on `@keyframes` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)