### PR TITLE
ci: upgrade Node.js to 26 (test job pinned to 24)

### DIFF
--- a/.github/workflows/check-generated-in-examples.yml
+++ b/.github/workflows/check-generated-in-examples.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: voidzero-dev/setup-vp@56918a6d0c629c55ae8b88826a7d47fda85769ee # v1.9.0
         with:
-          node-version: 24
+          node-version: 26
           cache: true
       - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: voidzero-dev/setup-vp@56918a6d0c629c55ae8b88826a7d47fda85769ee # v1.9.0
         with:
-          node-version: 24
+          node-version: 26
           cache: true
       - run: vp check
   build:
@@ -28,18 +28,27 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: voidzero-dev/setup-vp@56918a6d0c629c55ae8b88826a7d47fda85769ee # v1.9.0
         with:
-          node-version: 24
+          node-version: 26
           cache: true
       - run: vp run build
   test:
     strategy:
       fail-fast: false
       matrix:
-        node: [22, 24]
+        node: [26]
         os: [ubuntu-24.04-arm, macos-latest, windows-11-arm]
         stylelint-version: ['17']
         include:
+          # Configuration for Node.js 24
           - node: 24
+            os: ubuntu-24.04-arm
+            stylelint-version: '17'
+          # Configuration for Node.js 22
+          - node: 22
+            os: ubuntu-24.04-arm
+            stylelint-version: '17'
+          # Configuration for Stylelint 16
+          - node: 26
             os: ubuntu-24.04-arm
             stylelint-version: '16'
     runs-on: ${{ matrix.os }}
@@ -65,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22, 24]
+        node: [26]
         os: [ubuntu-24.04-arm, macos-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,20 +35,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [26]
+        # NOTE: We would like to test with Node.js 26 as well, but we are limited to Node.js 24 due to test failures on Windows.
+        # ref: https://github.com/libuv/libuv/issues/5010
+        node: [24]
         os: [ubuntu-24.04-arm, macos-latest, windows-11-arm]
         stylelint-version: ['17']
         include:
-          # Configuration for Node.js 24
-          - node: 24
-            os: ubuntu-24.04-arm
-            stylelint-version: '17'
           # Configuration for Node.js 22
           - node: 22
             os: ubuntu-24.04-arm
             stylelint-version: '17'
           # Configuration for Stylelint 16
-          - node: 26
+          - node: 24
             os: ubuntu-24.04-arm
             stylelint-version: '16'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: voidzero-dev/setup-vp@56918a6d0c629c55ae8b88826a7d47fda85769ee # v1.9.0
         with:
-          node-version: 24
+          node-version: 26
           cache: true
       - run: vp run build
       - name: set release variables


### PR DESCRIPTION
## Summary

- Bump the default Node.js version across CI workflows to 26 now that it has been released.
- Skip Node 26 in the `test` job due to a libuv issue ([libuv#5010](https://github.com/libuv/libuv/issues/5010)); test on Node 22 and 24 instead.
- Trim the test matrix to save CI resources.

## Changes

### `test` job
- Run on all 3 OSes (ubuntu / macos / windows) only for **Node 24 / stylelint 17**.
- Run Node 22 (stylelint 17) on **ubuntu only**.
- Run Node 24 (stylelint 16) on ubuntu only.
- Node 26 is excluded for now due to the libuv Windows issue (also documented in the workflow as a comment).

### `vscode-test` job
- Pin to Node 26 (drop Node 22 from the matrix).
- Rationale: The VS Code extension host runs tests with the Node.js bundled into VS Code, so the runner's Node.js version does not affect the tests.

### Other
- Bump `lint`, `build`, and `check-generated-in-examples` jobs to Node 26.
- Switch `release.yml` runner from `ubuntu-latest` to `ubuntu-24.04-arm` to match other jobs.

## Test plan

- [x] Confirm CI passes