### PR TITLE
feat(core, ts-plugin, eslint-plugin, stylelint-plugin): support composes property

### DIFF
--- a/.changeset/composes-local-references.md
+++ b/.changeset/composes-local-references.md
@@ -1,0 +1,17 @@
+---
+'@css-modules-kit/core': minor
+'@css-modules-kit/ts-plugin': minor
+'@css-modules-kit/eslint-plugin': patch
+'@css-modules-kit/stylelint-plugin': patch
+---
+
+feat(core, ts-plugin, eslint-plugin, stylelint-plugin): support composes property
+
+Class names referenced via `composes: foo;` are now linked back to the `.foo {...}` declaration. Go to Definition jumps from a reference to the declaration, Find All References lists every reference site, and Rename updates the declaration and every reference together. Space-separated names (`composes: foo bar;`), comma-separated names (`composes: foo, bar;`), and mixes of both are supported. `composes: global(foo);`, `composes: foo from global;`, and `composes: foo from '<specifier>';` do not produce references (support for `from '<specifier>'` is planned).
+
+Two diagnostics are also emitted for invalid usage:
+
+- Parse phase: a `from` clause not followed by a quoted specifier or the `global` keyword is reported.
+- Check phase: references that resolve to neither a locally defined token nor an imported token are reported as `Cannot find token '<name>'.`.
+
+The `no-unused-class-names` rule in eslint-plugin and stylelint-plugin now treats names referenced via `composes` from within the same CSS as used, so they are no longer reported as unused.

--- a/examples/1-basic/src/a.module.css
+++ b/examples/1-basic/src/a.module.css
@@ -7,6 +7,7 @@
   100% { transform: translateY(-100%); }
 }
 .a_5 {
+  composes: a_1;
   animation-name: a_4;
 }
 

--- a/packages/core/src/parser/animation-parser.ts
+++ b/packages/core/src/parser/animation-parser.ts
@@ -59,7 +59,7 @@ function createInvalidLocalCallDiagnostic(
   decl: Declaration,
   fn: postcssValueParser.FunctionNode,
 ): DiagnosticWithDetachedLocation {
-  const length = postcssValueParser.stringify(fn).length;
+  const length = fn.sourceEndIndex - fn.sourceIndex;
   const { start } = calcDeclValueLoc(decl, fn.sourceIndex, length);
   return {
     text: '`local(...)` must contain exactly one identifier.',

--- a/packages/core/src/parser/animation-parser.ts
+++ b/packages/core/src/parser/animation-parser.ts
@@ -1,6 +1,7 @@
 import type { Declaration } from 'postcss';
 import postcssValueParser from 'postcss-value-parser';
-import type { DiagnosticWithDetachedLocation, Location, TokenReference } from '../type.js';
+import type { DiagnosticWithDetachedLocation, TokenReference } from '../type.js';
+import { calcDeclValueLoc } from './decl-value-location.js';
 
 const ANIMATION_NAME_PROP_RE = /^(?:-(?:webkit|moz|o|ms)-)?animation-name$/iu;
 
@@ -29,12 +30,15 @@ export function parseAnimationNameProp(decl: Declaration): ParseAnimationResult 
         diagnostics.push(createInvalidLocalCallDiagnostic(decl, node));
         continue;
       }
-      references.push({ name: nameNodeOrError.value, loc: calcLoc(decl, nameNodeOrError) });
+      references.push({
+        name: nameNodeOrError.value,
+        loc: calcDeclValueLoc(decl, nameNodeOrError.sourceIndex, nameNodeOrError.value.length),
+      });
       continue;
     }
     if (node.type !== 'word') continue;
     if (COMMON_RESERVED_KEYWORDS.has(node.value.toLowerCase())) continue;
-    references.push({ name: node.value, loc: calcLoc(decl, node) });
+    references.push({ name: node.value, loc: calcDeclValueLoc(decl, node.sourceIndex, node.value.length) });
   }
   return { references, diagnostics };
 }
@@ -51,25 +55,16 @@ function unwrapLocalCall(fn: postcssValueParser.FunctionNode): postcssValueParse
   return 'invalid';
 }
 
-function calcLoc(decl: Declaration, animationNameNode: postcssValueParser.WordNode): Location {
-  const baseLength = decl.prop.length + decl.raws.between!.length;
-  const startIndex = baseLength + animationNameNode.sourceIndex;
-  return {
-    start: decl.positionBy({ index: startIndex }),
-    end: decl.positionBy({ index: startIndex + animationNameNode.value.length }),
-  };
-}
-
 function createInvalidLocalCallDiagnostic(
   decl: Declaration,
   fn: postcssValueParser.FunctionNode,
 ): DiagnosticWithDetachedLocation {
-  const baseLength = decl.prop.length + decl.raws.between!.length;
-  const start = decl.positionBy({ index: baseLength + fn.sourceIndex });
+  const length = postcssValueParser.stringify(fn).length;
+  const { start } = calcDeclValueLoc(decl, fn.sourceIndex, length);
   return {
     text: '`local(...)` must contain exactly one identifier.',
     category: 'error',
     start: { line: start.line, column: start.column },
-    length: postcssValueParser.stringify(fn).length,
+    length,
   };
 }

--- a/packages/core/src/parser/composes-parser.test.ts
+++ b/packages/core/src/parser/composes-parser.test.ts
@@ -1,0 +1,285 @@
+import dedent from 'dedent';
+import { describe, expect, test } from 'vite-plus/test';
+import { fakeDeclaration } from '../test/ast.js';
+import { isComposesProp, parseComposesProp } from './composes-parser.js';
+
+describe('isComposesProp', () => {
+  test.each([
+    ['composes', true],
+    ['Composes', true],
+    ['COMPOSES', true],
+    ['compose-with', false],
+    ['a-composes', false],
+    ['composes-b', false],
+    ['color', false],
+  ])('%s -> %s', (prop, expected) => {
+    expect(isComposesProp(prop)).toBe(expected);
+  });
+});
+
+describe('parseComposesProp', () => {
+  test('extracts a single class name', () => {
+    const decl = fakeDeclaration('.a_1 { composes: a_2 }');
+    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
+      {
+        "diagnostics": [],
+        "references": [
+          {
+            "loc": {
+              "end": {
+                "column": 21,
+                "line": 1,
+                "offset": 20,
+              },
+              "start": {
+                "column": 18,
+                "line": 1,
+                "offset": 17,
+              },
+            },
+            "name": "a_2",
+          },
+        ],
+      }
+    `);
+  });
+
+  test('extracts space-separated class names', () => {
+    const decl = fakeDeclaration('.a_1 { composes: a_2 a_3 }');
+    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
+      {
+        "diagnostics": [],
+        "references": [
+          {
+            "loc": {
+              "end": {
+                "column": 21,
+                "line": 1,
+                "offset": 20,
+              },
+              "start": {
+                "column": 18,
+                "line": 1,
+                "offset": 17,
+              },
+            },
+            "name": "a_2",
+          },
+          {
+            "loc": {
+              "end": {
+                "column": 25,
+                "line": 1,
+                "offset": 24,
+              },
+              "start": {
+                "column": 22,
+                "line": 1,
+                "offset": 21,
+              },
+            },
+            "name": "a_3",
+          },
+        ],
+      }
+    `);
+  });
+
+  test('extracts comma-separated class names', () => {
+    const decl = fakeDeclaration('.a_1 { composes: a_2, a_3 }');
+    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
+      {
+        "diagnostics": [],
+        "references": [
+          {
+            "loc": {
+              "end": {
+                "column": 21,
+                "line": 1,
+                "offset": 20,
+              },
+              "start": {
+                "column": 18,
+                "line": 1,
+                "offset": 17,
+              },
+            },
+            "name": "a_2",
+          },
+          {
+            "loc": {
+              "end": {
+                "column": 26,
+                "line": 1,
+                "offset": 25,
+              },
+              "start": {
+                "column": 23,
+                "line": 1,
+                "offset": 22,
+              },
+            },
+            "name": "a_3",
+          },
+        ],
+      }
+    `);
+  });
+
+  test('skips class name inside global()', () => {
+    const decl = fakeDeclaration('.a_1 { composes: global(a_2) }');
+    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
+      {
+        "diagnostics": [],
+        "references": [],
+      }
+    `);
+  });
+
+  test('skips items with from global', () => {
+    const decl = fakeDeclaration('.a_1 { composes: a_2 a_3 from global }');
+    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
+      {
+        "diagnostics": [],
+        "references": [],
+      }
+    `);
+  });
+
+  test('skips items with from specifier', () => {
+    const decl = fakeDeclaration(`.a_1 { composes: a_2 from './a.module.css' }`);
+    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
+      {
+        "diagnostics": [],
+        "references": [],
+      }
+    `);
+  });
+
+  test('extracts class names only from items without a from clause', () => {
+    const decl = fakeDeclaration(`.a_1 { composes: a_2, a_3 from './a.module.css', a_4 from global, a_5 }`);
+    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
+      {
+        "diagnostics": [],
+        "references": [
+          {
+            "loc": {
+              "end": {
+                "column": 21,
+                "line": 1,
+                "offset": 20,
+              },
+              "start": {
+                "column": 18,
+                "line": 1,
+                "offset": 17,
+              },
+            },
+            "name": "a_2",
+          },
+          {
+            "loc": {
+              "end": {
+                "column": 70,
+                "line": 1,
+                "offset": 69,
+              },
+              "start": {
+                "column": 67,
+                "line": 1,
+                "offset": 66,
+              },
+            },
+            "name": "a_5",
+          },
+        ],
+      }
+    `);
+  });
+
+  test('reports a diagnostic for from clause without quoted specifier or global keyword (unquoted specifier, empty, non-global word)', () => {
+    const decl = fakeDeclaration('.a_1 { composes: a_2 from ./a.module.css, a_3 from, a_4 from b_1 }');
+    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
+      {
+        "diagnostics": [
+          {
+            "category": "error",
+            "length": 19,
+            "start": {
+              "column": 22,
+              "line": 1,
+            },
+            "text": "\`from\` must be followed by a quoted specifier or \`global\`.",
+          },
+          {
+            "category": "error",
+            "length": 4,
+            "start": {
+              "column": 47,
+              "line": 1,
+            },
+            "text": "\`from\` must be followed by a quoted specifier or \`global\`.",
+          },
+          {
+            "category": "error",
+            "length": 8,
+            "start": {
+              "column": 57,
+              "line": 1,
+            },
+            "text": "\`from\` must be followed by a quoted specifier or \`global\`.",
+          },
+        ],
+        "references": [],
+      }
+    `);
+  });
+
+  test('extracts references on lines after the declaration start', () => {
+    const decl = fakeDeclaration(dedent`
+      .a_1 {
+        composes:
+          a_2,
+          a_3 from global,
+          a_4;
+      }
+    `);
+    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
+      {
+        "diagnostics": [],
+        "references": [
+          {
+            "loc": {
+              "end": {
+                "column": 8,
+                "line": 3,
+                "offset": 26,
+              },
+              "start": {
+                "column": 5,
+                "line": 3,
+                "offset": 23,
+              },
+            },
+            "name": "a_2",
+          },
+          {
+            "loc": {
+              "end": {
+                "column": 8,
+                "line": 5,
+                "offset": 56,
+              },
+              "start": {
+                "column": 5,
+                "line": 5,
+                "offset": 53,
+              },
+            },
+            "name": "a_4",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/packages/core/src/parser/composes-parser.ts
+++ b/packages/core/src/parser/composes-parser.ts
@@ -1,0 +1,78 @@
+import type { Declaration } from 'postcss';
+import postcssValueParser from 'postcss-value-parser';
+import type { DiagnosticWithDetachedLocation, TokenReference } from '../type.js';
+import { calcDeclValueLoc } from './decl-value-location.js';
+
+const COMPOSES_PROP_RE = /^composes$/iu;
+
+export function isComposesProp(prop: string): boolean {
+  return COMPOSES_PROP_RE.test(prop);
+}
+
+interface ParseComposesResult {
+  references: TokenReference[];
+  diagnostics: DiagnosticWithDetachedLocation[];
+}
+
+/** Parse a `composes` declaration and extract token references. */
+export function parseComposesProp(decl: Declaration): ParseComposesResult {
+  const references: TokenReference[] = [];
+  const diagnostics: DiagnosticWithDetachedLocation[] = [];
+  for (const item of splitByComma(postcssValueParser(decl.value).nodes)) {
+    const fromIndex = item.findLastIndex((node) => node.type === 'word' && node.value === 'from');
+    if (fromIndex === -1) {
+      for (const node of item) {
+        // `global(name)` and any other function are skipped.
+        if (node.type !== 'word') continue;
+        references.push({ name: node.value, loc: calcDeclValueLoc(decl, node.sourceIndex, node.value.length) });
+      }
+      continue;
+    }
+    if (!isValidFromClauseTail(item.slice(fromIndex + 1))) {
+      diagnostics.push(createInvalidFromClauseDiagnostic(decl, item, fromIndex));
+    }
+    // Items with `from global` and `from '<specifier>'` do not produce local token references.
+  }
+  return { references, diagnostics };
+}
+
+/** Split the value nodes by top-level commas. Space nodes are dropped. */
+function splitByComma(nodes: postcssValueParser.Node[]): postcssValueParser.Node[][] {
+  const items: postcssValueParser.Node[][] = [[]];
+  for (const node of nodes) {
+    if (node.type === 'div' && node.value === ',') {
+      items.push([]);
+    } else if (node.type !== 'space') {
+      items.at(-1)!.push(node);
+    }
+  }
+  return items;
+}
+
+/**
+ * Check that the nodes after `from` represent a valid import source: a single
+ * quoted specifier (e.g. `'./a.module.css'`) or the keyword `global`.
+ */
+function isValidFromClauseTail(tail: postcssValueParser.Node[]): boolean {
+  if (tail.length !== 1) return false;
+  const node = tail[0]!;
+  return node.type === 'string' || (node.type === 'word' && node.value === 'global');
+}
+
+function createInvalidFromClauseDiagnostic(
+  decl: Declaration,
+  item: postcssValueParser.Node[],
+  fromIndex: number,
+): DiagnosticWithDetachedLocation {
+  const fromNode = item[fromIndex]!;
+  const lastNode = item[item.length - 1]!;
+  const endIndex = lastNode.sourceIndex + postcssValueParser.stringify(lastNode).length;
+  const length = endIndex - fromNode.sourceIndex;
+  const { start } = calcDeclValueLoc(decl, fromNode.sourceIndex, length);
+  return {
+    text: '`from` must be followed by a quoted specifier or `global`.',
+    category: 'error',
+    start: { line: start.line, column: start.column },
+    length,
+  };
+}

--- a/packages/core/src/parser/composes-parser.ts
+++ b/packages/core/src/parser/composes-parser.ts
@@ -66,8 +66,7 @@ function createInvalidFromClauseDiagnostic(
 ): DiagnosticWithDetachedLocation {
   const fromNode = item[fromIndex]!;
   const lastNode = item[item.length - 1]!;
-  const endIndex = lastNode.sourceIndex + postcssValueParser.stringify(lastNode).length;
-  const length = endIndex - fromNode.sourceIndex;
+  const length = lastNode.sourceEndIndex - fromNode.sourceIndex;
   const { start } = calcDeclValueLoc(decl, fromNode.sourceIndex, length);
   return {
     text: '`from` must be followed by a quoted specifier or `global`.',

--- a/packages/core/src/parser/css-module-parser.test.ts
+++ b/packages/core/src/parser/css-module-parser.test.ts
@@ -677,6 +677,34 @@ describe('parseCSSModule', () => {
     	}
     `);
   });
+  test('collects token references from composes declarations', () => {
+    const parsed = parseCSSModule(
+      dedent`
+        .a_1 { color: red; }
+        .a_2 { composes: a_1; }
+      `,
+      options,
+    );
+    expect(parsed.tokenReferences).toMatchInlineSnapshot(`
+      [
+        {
+          "loc": {
+            "end": {
+              "column": 21,
+              "line": 2,
+              "offset": 41,
+            },
+            "start": {
+              "column": 18,
+              "line": 2,
+              "offset": 38,
+            },
+          },
+          "name": "a_1",
+        },
+      ]
+    `);
+  });
   test('collects diagnostics', () => {
     const parsed = parseCSSModule(
       dedent`

--- a/packages/core/src/parser/css-module-parser.ts
+++ b/packages/core/src/parser/css-module-parser.ts
@@ -12,6 +12,7 @@ import type {
 import { isAnimationNameProp, parseAnimationNameProp } from './animation-parser.js';
 import { parseAtImport } from './at-import-parser.js';
 import { parseAtValue } from './at-value-parser.js';
+import { isComposesProp, parseComposesProp } from './composes-parser.js';
 import { parseAtKeyframes } from './key-frame-parser.js';
 import { parseRule } from './rule-parser.js';
 
@@ -81,6 +82,10 @@ function collectTokens(ast: Root, keyframes: boolean) {
       }
     } else if (keyframes && isDeclarationNode(node) && isAnimationNameProp(node.prop)) {
       const { references, diagnostics } = parseAnimationNameProp(node);
+      allDiagnostics.push(...diagnostics);
+      tokenReferences.push(...references);
+    } else if (isDeclarationNode(node) && isComposesProp(node.prop)) {
+      const { references, diagnostics } = parseComposesProp(node);
       allDiagnostics.push(...diagnostics);
       tokenReferences.push(...references);
     }

--- a/packages/core/src/parser/decl-value-location.ts
+++ b/packages/core/src/parser/decl-value-location.ts
@@ -1,0 +1,16 @@
+import type { Declaration } from 'postcss';
+import type { Location } from '../type.js';
+
+/**
+ * Calculate the location of a range in the value of a declaration.
+ * @param sourceIndex The index of the range in the declaration value.
+ * @param length The length of the range.
+ */
+export function calcDeclValueLoc(decl: Declaration, sourceIndex: number, length: number): Location {
+  const baseLength = decl.prop.length + decl.raws.between!.length;
+  const startIndex = baseLength + sourceIndex;
+  return {
+    start: decl.positionBy({ index: startIndex }),
+    end: decl.positionBy({ index: startIndex + length }),
+  };
+}

--- a/packages/core/src/util.test.ts
+++ b/packages/core/src/util.test.ts
@@ -46,4 +46,8 @@ describe('findUsedTokenNames', () => {
     const root = fakeRoot('.a_3 { animation-name: a_1, a_2; }');
     expect(findUsedTokenNames('styles.a_3;', root)).toEqual(new Set(['a_1', 'a_2', 'a_3']));
   });
+  test('collects token names referenced from composes in the CSS module', () => {
+    const root = fakeRoot('.a_3 { composes: a_1 a_2; }');
+    expect(findUsedTokenNames('styles.a_3;', root)).toEqual(new Set(['a_1', 'a_2', 'a_3']));
+  });
 });

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -1,5 +1,6 @@
 import type { Root } from 'postcss';
 import { isAnimationNameProp, parseAnimationNameProp } from './parser/animation-parser.js';
+import { isComposesProp, parseComposesProp } from './parser/composes-parser.js';
 
 export function isPosixRelativePath(path: string): boolean {
   return path.startsWith(`./`) || path.startsWith(`../`);
@@ -42,9 +43,9 @@ const TOKEN_CONSUMER_PATTERN =
  *
  * A token name is considered used if it is referenced from the component file
  * (via a `styles.<name>` style pattern) or from within the CSS module itself
- * (e.g. via `animation-name: <name>`). The latter is collected by walking
- * `root` so that callers can pass an already-parsed PostCSS AST to avoid an
- * extra parse.
+ * (e.g. via `animation-name: <name>` or `composes: <name>`). The latter is
+ * collected by walking `root` so that callers can pass an already-parsed
+ * PostCSS AST to avoid an extra parse.
  */
 export function findUsedTokenNames(componentText: string, root: Root): Set<string> {
   const usedClassNames = new Set<string>();
@@ -53,8 +54,14 @@ export function findUsedTokenNames(componentText: string, root: Root): Set<strin
     if (name) usedClassNames.add(name);
   }
   root.walkDecls((decl) => {
-    if (!isAnimationNameProp(decl.prop)) return;
-    const { references } = parseAnimationNameProp(decl);
+    let references;
+    if (isAnimationNameProp(decl.prop)) {
+      ({ references } = parseAnimationNameProp(decl));
+    } else if (isComposesProp(decl.prop)) {
+      ({ references } = parseComposesProp(decl));
+    } else {
+      return;
+    }
     for (const reference of references) {
       usedClassNames.add(reference.name);
     }


### PR DESCRIPTION
ref: #255
Claude Session: [2026-06-11-feat-composes-local-token-references.txt](https://github.com/user-attachments/files/28843574/2026-06-11-feat-composes-local-token-references.txt)


## Summary

Class names referenced via `composes: foo;` are now collected as token references, in the same way as `animation-name`. This enables:

- Go to Definition / Find All References / Rename between a `composes` reference and the class declaration
- `Cannot find token '<name>'.` diagnostic for unresolvable references
- A new parse-phase diagnostic for a `from` clause not followed by a quoted specifier or the `global` keyword
- `no-unused-class-names` (eslint-plugin / stylelint-plugin) treats names referenced via `composes` as used

Supported value syntax (verified against css-loader internals: postcss-modules-scope / postcss-modules-extract-imports):

- `composes: foo;` / `composes: foo bar;` / `composes: foo, bar;` → local token references
- `composes: global(foo);` / `composes: foo from global;` → ignored by design
- `composes: foo from './other.module.css';` → ignored for now; cross-file references are planned as a follow-up PR

## Implementation notes

- The value is parsed with postcss-value-parser rather than regexes like at-value-parser. This keeps the implementation simple, since reference locations can be derived directly from each parsed node
- `calcLoc` in animation-parser is extracted to `decl-value-location.ts` and shared with the new composes-parser
- Following webpack's regex backtracking behavior, the last `from` word in an item is used as the separator

## How to verify

1. Open `examples/1-basic/src/a.module.css` in an editor with the ts-plugin enabled
2. On `composes: a_1;` in `.a_5`, try Go to Definition (jumps to `.a_1`), Find All References, and Rename
3. Change the value to an undefined class name and confirm `Cannot find token` is reported
4. Change the value to `a_1 from ./b.module.css` (unquoted) and confirm the `` `from` must be followed by a quoted specifier or `global`. `` diagnostic is reported

https://github.com/user-attachments/assets/2f8a6e0c-a9ff-4702-83aa-267e9bafc382

🤖 Generated with [Claude Code](https://claude.com/claude-code)