### PR TITLE
feat(core, ts-plugin): support composes property with from specifier

### DIFF
--- a/.changeset/composes-external-references.md
+++ b/.changeset/composes-external-references.md
@@ -1,0 +1,13 @@
+---
+'@css-modules-kit/core': minor
+'@css-modules-kit/ts-plugin': minor
+---
+
+feat(core, ts-plugin): support `composes: <name> from '<specifier>'`
+
+Class names referenced via `composes: foo from './other.module.css';` are now linked to the `.foo {...}` declaration in the referenced file. Go to Definition jumps from the reference to the declaration, Find All References lists reference sites across files, and Rename updates the declaration and every reference together.
+
+Two diagnostics are also emitted in the check phase:
+
+- `Cannot import module '<specifier>'` when the specifier cannot be resolved.
+- `Module '<specifier>' has no exported token '<name>'.` when the referenced file does not export the token.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,9 @@ function myFunction() {
 ## Glossary
 
 - **Token**: A generic term for things exported by CSS Modules, such as class names, `@value` definitions, and `@keyframes` names.
-- **Token reference**: A usage of a token elsewhere in the CSS. Currently produced for `animation-name: <name>`. The referenced token may be defined in the same file (e.g. `@keyframes`) or imported via `@import` / `@value ... from`.
+- **Token reference**: A usage of a token elsewhere in the CSS. Currently produced for `animation-name: <name>` and `composes: <name>`. There are two kinds:
+  - **Local token reference**: References a token available in the current file. The token may be defined in the same file (e.g. `@keyframes`) or imported via `@import` / `@value ... from`.
+  - **External token reference**: References tokens exported by another file, like `composes: <name> ... from '<specifier>'`. One reference corresponds to one `from` clause and holds an entry per referenced token.
 - **Diagnostic**: An object representing errors or warnings
 - **Parse phase**: The phase that parses CSS Modules files and extracts token information
 - **Check phase**: The phase that validates CSS Modules files

--- a/docs/ts-plugin-internals.ja.md
+++ b/docs/ts-plugin-internals.ja.md
@@ -302,9 +302,9 @@ CSS Modules Kit ではこの問題を、
 
 参考: [mizdra/volar-single-quote-span-problem](https://github.com/mizdra/volar-single-quote-span-problem)
 
-### Token References (`animation-name`) のサポート
+### Local Token References (`animation-name`, `composes`) のサポート
 
-CSS では `@keyframes foo {...}` で定義したアニメーション名を `animation-name: foo;` で参照できます。CSS Modules Kit はこの参照を Volar.js の mapping を介して定義側と結びつけ、Go to Definition / Find All References / Rename を一貫して動作させます。
+CSS では `@keyframes foo {...}` で定義したアニメーション名を `animation-name: foo;` で参照できます。また CSS Modules では `composes: foo;` で同一ファイル内の別のクラス名を参照できます。CSS Modules Kit はこうした現在のファイルで利用可能なトークンへの参照 (local token reference) を Volar.js の mapping を介して定義側と結びつけ、Go to Definition / Find All References / Rename を一貫して動作させます。
 
 仕組みとしては、生成する `.d.ts` の末尾に「参照の式」を埋め込みます。default export の場合は `styles['<name>'];` という bracket access の式文として、named export の場合は自モジュールへの self-import (`declare const __self: typeof import('./<self-basename>');`) を 1 度生成した上で `__self['<name>'];` という bracket access として吐きます。各参照式のクオート内側部分には CSS 側の参照位置の mapping を張ります。
 
@@ -339,4 +339,36 @@ var _token_1: string;
 export { _token_1 as 'a_2' };
 declare const __self: typeof import('./a.module.css');
 __self['a_1'];
+```
+
+### External Token References (`composes: ... from '<specifier>'`) のサポート
+
+CSS Modules では `composes: b_1 b_2 from './b.module.css';` のように、`from` 句で指定した別ファイルのトークンを参照できます。CSS Modules Kit はこうした別ファイルがエクスポートするトークンへの参照 (external token reference) も、local token reference と同じく参照式と mapping によって定義側と結びつけます。
+
+例えば、次のような CSS モジュールがあるとします:
+
+`src/a.module.css`:
+
+```css
+.a_1 { composes: b_1 b_2 from './b.module.css'; }
+```
+
+default export の場合、次のような型定義が生成されます:
+
+```ts
+declare const styles = {
+  'a_1': '' as string,
+} as const;
+(await import('./b.module.css')).default['b_1'];
+(await import('./b.module.css')).default['b_2'];
+export default styles;
+```
+
+named export の場合、次のような型定義が生成されます:
+
+```ts
+var _token_0: string;
+export { _token_0 as 'a_1' };
+(await import('./b.module.css'))['b_1'];
+(await import('./b.module.css'))['b_2'];
 ```

--- a/docs/ts-plugin-internals.md
+++ b/docs/ts-plugin-internals.md
@@ -305,9 +305,9 @@ With this, `getDefinitionAtPosition`'s `{ start: 27, length: 5 }` also matches t
 
 Reference: [mizdra/volar-single-quote-span-problem](https://github.com/mizdra/volar-single-quote-span-problem)
 
-### Token References (`animation-name`) Support
+### Local Token References (`animation-name`, `composes`) Support
 
-In CSS, an animation name defined with `@keyframes foo {...}` can be referenced by `animation-name: foo;`. CSS Modules Kit links such references to their definitions via Volar.js mappings, making Go to Definition / Find All References / Rename work consistently.
+In CSS, an animation name defined with `@keyframes foo {...}` can be referenced by `animation-name: foo;`. In CSS Modules, `composes: foo;` can also reference another class name in the same file. CSS Modules Kit links such references to tokens available in the current file (local token references) to their definitions via Volar.js mappings, making Go to Definition / Find All References / Rename work consistently.
 
 The mechanism is to embed "reference expressions" at the end of the generated `.d.ts`. For default export, it is emitted as a bracket access expression statement like `styles['<name>'];`. For named export, after emitting a self-import (`declare const __self: typeof import('./<self-basename>');`) once, it is emitted as a bracket access like `__self['<name>'];`. A mapping is attached to the inside-of-quotes part of each reference expression, pointing to the reference position in the CSS.
 
@@ -342,4 +342,36 @@ var _token_1: string;
 export { _token_1 as 'a_2' };
 declare const __self: typeof import('./a.module.css');
 __self['a_1'];
+```
+
+### External Token References (`composes: ... from '<specifier>'`) Support
+
+In CSS Modules, tokens of another file can be referenced with a `from` clause, like `composes: b_1 b_2 from './b.module.css';`. CSS Modules Kit links such references to tokens exported by another file (external token references) to their definitions via reference expressions and mappings, just like local token references.
+
+For example, suppose we have the following CSS module:
+
+`src/a.module.css`:
+
+```css
+.a_1 { composes: b_1 b_2 from './b.module.css'; }
+```
+
+For default export, the following type definition is generated:
+
+```ts
+declare const styles = {
+  'a_1': '' as string,
+} as const;
+(await import('./b.module.css')).default['b_1'];
+(await import('./b.module.css')).default['b_2'];
+export default styles;
+```
+
+For named export, the following type definition is generated:
+
+```ts
+var _token_0: string;
+export { _token_0 as 'a_1' };
+(await import('./b.module.css'))['b_1'];
+(await import('./b.module.css'))['b_2'];
 ```

--- a/examples/1-basic/src/a.module.css
+++ b/examples/1-basic/src/a.module.css
@@ -7,7 +7,7 @@
   100% { transform: translateY(-100%); }
 }
 .a_5 {
-  composes: a_1;
+  composes: a_1, b_1 from './b.module.css';
   animation-name: a_4;
 }
 

--- a/packages/core/src/checker.test.ts
+++ b/packages/core/src/checker.test.ts
@@ -300,4 +300,59 @@ describe('checkCSSModule', () => {
     const diagnostics = check(readAndParseCSSModule(iff.paths['a.module.css'])!);
     expect(diagnostics).toEqual([]);
   });
+  test('report diagnostics for external references with unresolvable modules', async () => {
+    // The diagnostic is reported once per `from` clause, even if it has multiple entries.
+    const iff = await createIFF({
+      'a.module.css': `.a_1 { composes: b_1 b_2 from './b.module.css'; }`,
+    });
+    const check = prepareChecker();
+    const diagnostics = check(readAndParseCSSModule(iff.paths['a.module.css'])!);
+    expect(formatDiagnostics(diagnostics, iff.rootDir)).toMatchInlineSnapshot(`
+      [
+        {
+          "category": "error",
+          "fileName": "<rootDir>/a.module.css",
+          "length": 14,
+          "start": {
+            "column": 32,
+            "line": 1,
+          },
+          "text": "Cannot import module './b.module.css'",
+        },
+      ]
+    `);
+  });
+  test('report diagnostics for external references to non-exported tokens', async () => {
+    const iff = await createIFF({
+      'a.module.css': `.a_1 { composes: b_1 b_2 from './b.module.css'; }`,
+      'b.module.css': `.b_1 { color: red; }`,
+    });
+    const check = prepareChecker();
+    const diagnostics = check(readAndParseCSSModule(iff.paths['a.module.css'])!);
+    expect(formatDiagnostics(diagnostics, iff.rootDir)).toMatchInlineSnapshot(`
+      [
+        {
+          "category": "error",
+          "fileName": "<rootDir>/a.module.css",
+          "length": 3,
+          "start": {
+            "column": 22,
+            "line": 1,
+          },
+          "text": "Module './b.module.css' has no exported token 'b_2'.",
+        },
+      ]
+    `);
+  });
+  test('do not report diagnostics for external references for unmatched modules', async () => {
+    const iff = await createIFF({
+      'a.module.css': `.a_1 { composes: unmatched_1 from './unmatched.module.css'; }`,
+      'unmatched.module.css': '.unmatched_1 { color: red; }',
+    });
+    const check = prepareChecker({
+      matchesPattern: (path) => path.endsWith('.module.css') && !path.endsWith('unmatched.module.css'),
+    });
+    const diagnostics = check(readAndParseCSSModule(iff.paths['a.module.css'])!);
+    expect(diagnostics).toEqual([]);
+  });
 });

--- a/packages/core/src/checker.ts
+++ b/packages/core/src/checker.ts
@@ -4,12 +4,9 @@ import type {
   Diagnostic,
   ExportRecord,
   Location,
+  LocalTokenReference,
   MatchesPattern,
-  NamedTokenImporter,
-  NamedTokenImporterEntry,
   Resolver,
-  TokenImporter,
-  TokenReference,
 } from './type.js';
 import { isURLSpecifier, type TokenNameViolation, validateTokenName } from './util.js';
 
@@ -37,7 +34,7 @@ export function checkCSSModule(cssModule: CSSModule, args: CheckerArgs): Diagnos
     if (isURLSpecifier(tokenImporter.from)) continue;
     const from = args.resolver(tokenImporter.from, { request: cssModule.fileName });
     if (!from) {
-      diagnostics.push(createCannotImportModuleDiagnostic(cssModule, tokenImporter));
+      diagnostics.push(createCannotImportModuleDiagnostic(cssModule, tokenImporter.from, tokenImporter.fromLoc));
       continue;
     }
     if (!args.matchesPattern(from)) continue;
@@ -48,7 +45,9 @@ export function checkCSSModule(cssModule: CSSModule, args: CheckerArgs): Diagnos
       const exportRecord = args.getExportRecord(imported);
       for (const entry of tokenImporter.entries) {
         if (!exportRecord.allTokens.includes(entry.name)) {
-          diagnostics.push(createModuleHasNoExportedTokenDiagnostic(cssModule, tokenImporter, entry));
+          diagnostics.push(
+            createModuleHasNoExportedTokenDiagnostic(cssModule, tokenImporter.from, entry.name, entry.loc),
+          );
         }
         const nameViolation = validateTokenName(entry.name, { namedExports: config.namedExports });
         if (nameViolation) {
@@ -66,8 +65,26 @@ export function checkCSSModule(cssModule: CSSModule, args: CheckerArgs): Diagnos
 
   const exportRecord = args.getExportRecord(cssModule);
   for (const reference of cssModule.tokenReferences) {
-    if (!exportRecord.allTokens.includes(reference.name)) {
-      diagnostics.push(createTokenNotFoundDiagnostic(cssModule, reference));
+    if (reference.type === 'local') {
+      if (!exportRecord.allTokens.includes(reference.name)) {
+        diagnostics.push(createTokenNotFoundDiagnostic(cssModule, reference));
+      }
+      continue;
+    }
+    // Unlike `@import`, URL specifiers are not skipped because css-loader fails to resolve them in `composes`.
+    const from = args.resolver(reference.from, { request: cssModule.fileName });
+    if (!from) {
+      diagnostics.push(createCannotImportModuleDiagnostic(cssModule, reference.from, reference.fromLoc));
+      continue;
+    }
+    if (!args.matchesPattern(from)) continue;
+    const imported = args.getCSSModule(from);
+    if (!imported) throw new Error('unreachable: `imported` is undefined');
+    const importedExportRecord = args.getExportRecord(imported);
+    for (const entry of reference.entries) {
+      if (!importedExportRecord.allTokens.includes(entry.name)) {
+        diagnostics.push(createModuleHasNoExportedTokenDiagnostic(cssModule, reference.from, entry.name, entry.loc));
+      }
     }
   }
   return diagnostics;
@@ -97,31 +114,32 @@ function createTokenNameDiagnostic(cssModule: CSSModule, loc: Location, violatio
   };
 }
 
-function createCannotImportModuleDiagnostic(cssModule: CSSModule, tokenImporter: TokenImporter): Diagnostic {
+function createCannotImportModuleDiagnostic(cssModule: CSSModule, from: string, fromLoc: Location): Diagnostic {
   return {
-    text: `Cannot import module '${tokenImporter.from}'`,
+    text: `Cannot import module '${from}'`,
     category: 'error',
     file: { fileName: cssModule.fileName, text: cssModule.text },
-    start: { line: tokenImporter.fromLoc.start.line, column: tokenImporter.fromLoc.start.column },
-    length: tokenImporter.fromLoc.end.offset - tokenImporter.fromLoc.start.offset,
+    start: { line: fromLoc.start.line, column: fromLoc.start.column },
+    length: fromLoc.end.offset - fromLoc.start.offset,
   };
 }
 
 function createModuleHasNoExportedTokenDiagnostic(
   cssModule: CSSModule,
-  tokenImporter: NamedTokenImporter,
-  entry: NamedTokenImporterEntry,
+  from: string,
+  name: string,
+  loc: Location,
 ): Diagnostic {
   return {
-    text: `Module '${tokenImporter.from}' has no exported token '${entry.name}'.`,
+    text: `Module '${from}' has no exported token '${name}'.`,
     category: 'error',
     file: { fileName: cssModule.fileName, text: cssModule.text },
-    start: { line: entry.loc.start.line, column: entry.loc.start.column },
-    length: entry.loc.end.offset - entry.loc.start.offset,
+    start: { line: loc.start.line, column: loc.start.column },
+    length: loc.end.offset - loc.start.offset,
   };
 }
 
-function createTokenNotFoundDiagnostic(cssModule: CSSModule, reference: TokenReference): Diagnostic {
+function createTokenNotFoundDiagnostic(cssModule: CSSModule, reference: LocalTokenReference): Diagnostic {
   return {
     text: `Cannot find token '${reference.name}'.`,
     category: 'error',

--- a/packages/core/src/dts-generator.test.ts
+++ b/packages/core/src/dts-generator.test.ts
@@ -370,6 +370,90 @@ describe('emits token reference statements when forTsPlugin is true', () => {
   });
 });
 
+describe('emits external token reference statements when forTsPlugin is true', () => {
+  // `b_1` and `b_2` share one `from` clause. The `from` clause of `b_3` has the same specifier
+  // as the first one, but is a separate clause.
+  const source = `.a_1 { composes: b_1 b_2 from './b.module.css', b_3 from './b.module.css'; }`;
+  test('default export', async () => {
+    expect(await run(source, { ...defaultExportOptions, forTsPlugin: true })).toMatchInlineSnapshot(`
+      "=== source ===
+      .a_1 { composes: b_1 b_2 from './b.module.css', b_3 from './b.module.css'; }
+                                                               ^^^^^^^^^^^^^^^^ mapping[4]
+                                                      ^^^ mapping[5]
+                                    ^^^^^^^^^^^^^^^^ mapping[1]
+                           ^^^ mapping[3]
+                       ^^^ mapping[2]
+       ^^^ mapping[0]
+
+      === generated ===
+      // @ts-nocheck
+      declare const styles = {
+        'a_1': '' as string,
+         ^^^ mapping[0]
+      } as const;
+      (await import('./b.module.css')).default['b_1'];
+                                                ^^^ mapping[2]
+                    ^^^^^^^^^^^^^^^^ mapping[1]
+      (await import('./b.module.css')).default['b_2'];
+                                                ^^^ mapping[3]
+      (await import('./b.module.css')).default['b_3'];
+                                                ^^^ mapping[5]
+                    ^^^^^^^^^^^^^^^^ mapping[4]
+      export default styles;
+      "
+    `);
+  });
+  test('named export', async () => {
+    expect(await run(source, { ...namedExportOptions, forTsPlugin: true })).toMatchInlineSnapshot(`
+      "=== source ===
+      .a_1 { composes: b_1 b_2 from './b.module.css', b_3 from './b.module.css'; }
+                                                               ^^^^^^^^^^^^^^^^ mapping[4]
+                                                      ^^^ mapping[5]
+                                    ^^^^^^^^^^^^^^^^ mapping[1]
+                           ^^^ mapping[3]
+                       ^^^ mapping[2]
+       ^^^ mapping[0]
+
+      === generated ===
+      // @ts-nocheck
+      var _token_0: string;
+          ^^^^^^^^ mapping[0]
+      export { _token_0 as 'a_1' };
+                           ^^^^^ linkedCodeMapping[0]
+               ^^^^^^^^ linkedCodeMapping[0]
+      (await import('./b.module.css'))['b_1'];
+                                        ^^^ mapping[2]
+                    ^^^^^^^^^^^^^^^^ mapping[1]
+      (await import('./b.module.css'))['b_2'];
+                                        ^^^ mapping[3]
+      (await import('./b.module.css'))['b_3'];
+                                        ^^^ mapping[5]
+                    ^^^^^^^^^^^^^^^^ mapping[4]
+      declare const styles: {};
+      export default styles;
+      "
+    `);
+  });
+});
+
+test('omits external token reference statements whose specifier is a URL', async () => {
+  const source = `.a_1 { composes: b_1 from 'https://example.com/b.module.css'; }`;
+  expect(await run(source, { ...defaultExportOptions, forTsPlugin: true })).toMatchInlineSnapshot(`
+    "=== source ===
+    .a_1 { composes: b_1 from 'https://example.com/b.module.css'; }
+     ^^^ mapping[0]
+
+    === generated ===
+    // @ts-nocheck
+    declare const styles = {
+      'a_1': '' as string,
+       ^^^ mapping[0]
+    } as const;
+    export default styles;
+    "
+  `);
+});
+
 describe('omits importers whose specifier is a URL', () => {
   const source = dedent`
     @import 'https://example.com/b.module.css';

--- a/packages/core/src/dts-generator.ts
+++ b/packages/core/src/dts-generator.ts
@@ -48,7 +48,19 @@ export interface GenerateDtsResult {
 export function generateDts(cssModule: CSSModule, options: GenerateDtsOptions): GenerateDtsResult {
   // Exclude invalid tokens
   const localTokens = cssModule.localTokens.filter((token) => isValidTokenName(token.name, options));
-  const tokenReferences = cssModule.tokenReferences.filter((ref) => isValidTokenName(ref.name, options));
+  const tokenReferences = cssModule.tokenReferences
+    // Exclude invalid referenced tokens
+    .map((ref) => {
+      if (ref.type === 'external') {
+        return { ...ref, entries: ref.entries.filter((entry) => isValidTokenName(entry.name, options)) };
+      }
+      return ref;
+    })
+    .filter((ref) => {
+      if (ref.type === 'local') return isValidTokenName(ref.name, options);
+      // Like token importers, external references with URL specifiers are excluded
+      return !isURLSpecifier(ref.from);
+    });
   const tokenImporters = cssModule.tokenImporters
     // Exclude invalid imported tokens
     .map((tokenImporter) => {
@@ -209,14 +221,34 @@ function generateNamedExportsDts(
   }
 
   if (options.forTsPlugin && tokenReferences.length > 0) {
-    text += `declare const __self: typeof import('./${basename(fileName)}');\n`;
+    if (tokenReferences.some((ref) => ref.type === 'local')) {
+      text += `declare const __self: typeof import('./${basename(fileName)}');\n`;
+    }
     for (const ref of tokenReferences) {
-      text += `__self['`;
-      mapping.sourceOffsets.push(ref.loc.start.offset);
-      mapping.lengths.push(ref.name.length);
-      mapping.generatedOffsets.push(text.length);
-      mapping.generatedLengths.push(ref.name.length);
-      text += `${ref.name}'];\n`;
+      if (ref.type === 'local') {
+        text += `__self['`;
+        mapping.sourceOffsets.push(ref.loc.start.offset);
+        mapping.lengths.push(ref.name.length);
+        mapping.generatedOffsets.push(text.length);
+        mapping.generatedLengths.push(ref.name.length);
+        text += `${ref.name}'];\n`;
+        continue;
+      }
+      for (const [i, entry] of ref.entries.entries()) {
+        text += `(await import(`;
+        if (i === 0) {
+          mapping.sourceOffsets.push(ref.fromLoc.start.offset - 1);
+          mapping.lengths.push(ref.from.length + 2);
+          mapping.generatedOffsets.push(text.length);
+          mapping.generatedLengths.push(ref.from.length + 2);
+        }
+        text += `'${ref.from}'))['`;
+        mapping.sourceOffsets.push(entry.loc.start.offset);
+        mapping.lengths.push(entry.name.length);
+        mapping.generatedOffsets.push(text.length);
+        mapping.generatedLengths.push(entry.name.length);
+        text += `${entry.name}'];\n`;
+      }
     }
   }
   if (options.forTsPlugin && !options.prioritizeNamedImports) {
@@ -310,11 +342,27 @@ function generateDefaultExportDts(
 
   if (options.forTsPlugin) {
     for (const ref of tokenReferences) {
-      text += `${STYLES_EXPORT_NAME}['`;
-      mapping.sourceOffsets.push(ref.loc.start.offset);
-      mapping.lengths.push(ref.name.length);
-      mapping.generatedOffsets.push(text.length);
-      text += `${ref.name}'];\n`;
+      if (ref.type === 'local') {
+        text += `${STYLES_EXPORT_NAME}['`;
+        mapping.sourceOffsets.push(ref.loc.start.offset);
+        mapping.lengths.push(ref.name.length);
+        mapping.generatedOffsets.push(text.length);
+        text += `${ref.name}'];\n`;
+        continue;
+      }
+      for (const [i, entry] of ref.entries.entries()) {
+        text += `(await import(`;
+        if (i === 0) {
+          mapping.sourceOffsets.push(ref.fromLoc.start.offset - 1);
+          mapping.lengths.push(ref.from.length + 2);
+          mapping.generatedOffsets.push(text.length);
+        }
+        text += `'${ref.from}')).default['`;
+        mapping.sourceOffsets.push(entry.loc.start.offset);
+        mapping.lengths.push(entry.name.length);
+        mapping.generatedOffsets.push(text.length);
+        text += `${entry.name}'];\n`;
+      }
     }
   }
   text += `export default ${STYLES_EXPORT_NAME};\n`;

--- a/packages/core/src/parser/animation-parser.test.ts
+++ b/packages/core/src/parser/animation-parser.test.ts
@@ -22,93 +22,97 @@ describe('parseAnimationNameProp', () => {
   test('extracts a single ident', () => {
     const decl = fakeDeclaration('.a_1 { animation-name: a_2 }');
     expect(parseAnimationNameProp(decl)).toMatchInlineSnapshot(`
-    	{
-    	  "diagnostics": [],
-    	  "references": [
-    	    {
-    	      "loc": {
-    	        "end": {
-    	          "column": 27,
-    	          "line": 1,
-    	          "offset": 26,
-    	        },
-    	        "start": {
-    	          "column": 24,
-    	          "line": 1,
-    	          "offset": 23,
-    	        },
-    	      },
-    	      "name": "a_2",
-    	    },
-    	  ],
-    	}
+      {
+        "diagnostics": [],
+        "references": [
+          {
+            "loc": {
+              "end": {
+                "column": 27,
+                "line": 1,
+                "offset": 26,
+              },
+              "start": {
+                "column": 24,
+                "line": 1,
+                "offset": 23,
+              },
+            },
+            "name": "a_2",
+            "type": "local",
+          },
+        ],
+      }
     `);
   });
 
   test('extracts comma-separated idents', () => {
     const decl = fakeDeclaration('.a_1 { animation-name: a_2, a_3 }');
     expect(parseAnimationNameProp(decl)).toMatchInlineSnapshot(`
-    	{
-    	  "diagnostics": [],
-    	  "references": [
-    	    {
-    	      "loc": {
-    	        "end": {
-    	          "column": 27,
-    	          "line": 1,
-    	          "offset": 26,
-    	        },
-    	        "start": {
-    	          "column": 24,
-    	          "line": 1,
-    	          "offset": 23,
-    	        },
-    	      },
-    	      "name": "a_2",
-    	    },
-    	    {
-    	      "loc": {
-    	        "end": {
-    	          "column": 32,
-    	          "line": 1,
-    	          "offset": 31,
-    	        },
-    	        "start": {
-    	          "column": 29,
-    	          "line": 1,
-    	          "offset": 28,
-    	        },
-    	      },
-    	      "name": "a_3",
-    	    },
-    	  ],
-    	}
+      {
+        "diagnostics": [],
+        "references": [
+          {
+            "loc": {
+              "end": {
+                "column": 27,
+                "line": 1,
+                "offset": 26,
+              },
+              "start": {
+                "column": 24,
+                "line": 1,
+                "offset": 23,
+              },
+            },
+            "name": "a_2",
+            "type": "local",
+          },
+          {
+            "loc": {
+              "end": {
+                "column": 32,
+                "line": 1,
+                "offset": 31,
+              },
+              "start": {
+                "column": 29,
+                "line": 1,
+                "offset": 28,
+              },
+            },
+            "name": "a_3",
+            "type": "local",
+          },
+        ],
+      }
     `);
   });
 
   test('extracts ident from local()', () => {
     const decl = fakeDeclaration('.a_1 { animation-name: local(a_2) }');
     expect(parseAnimationNameProp(decl)).toMatchInlineSnapshot(`
-    	{
-    	  "diagnostics": [],
-    	  "references": [
-    	    {
-    	      "loc": {
-    	        "end": {
-    	          "column": 33,
-    	          "line": 1,
-    	          "offset": 32,
-    	        },
-    	        "start": {
-    	          "column": 30,
-    	          "line": 1,
-    	          "offset": 29,
-    	        },
-    	      },
-    	      "name": "a_2",
-    	    },
-    	  ],
-    	}
+      {
+        "diagnostics": [],
+        "references": [
+          {
+            "loc": {
+              "end": {
+                "column": 33,
+                "line": 1,
+                "offset": 32,
+              },
+              "start": {
+                "column": 30,
+                "line": 1,
+                "offset": 29,
+              },
+            },
+            "name": "a_2",
+            "type": "local",
+          },
+        ],
+      }
     `);
   });
 
@@ -145,26 +149,27 @@ describe('parseAnimationNameProp', () => {
   test('skips reserved keywords (none, revert, revert-layer)', () => {
     const decl = fakeDeclaration('.a_1 { animation-name: revert, a_2, none }');
     expect(parseAnimationNameProp(decl)).toMatchInlineSnapshot(`
-    	{
-    	  "diagnostics": [],
-    	  "references": [
-    	    {
-    	      "loc": {
-    	        "end": {
-    	          "column": 35,
-    	          "line": 1,
-    	          "offset": 34,
-    	        },
-    	        "start": {
-    	          "column": 32,
-    	          "line": 1,
-    	          "offset": 31,
-    	        },
-    	      },
-    	      "name": "a_2",
-    	    },
-    	  ],
-    	}
+      {
+        "diagnostics": [],
+        "references": [
+          {
+            "loc": {
+              "end": {
+                "column": 35,
+                "line": 1,
+                "offset": 34,
+              },
+              "start": {
+                "column": 32,
+                "line": 1,
+                "offset": 31,
+              },
+            },
+            "name": "a_2",
+            "type": "local",
+          },
+        ],
+      }
     `);
   });
 
@@ -216,51 +221,53 @@ describe('parseAnimationNameProp', () => {
       }
     `);
     expect(parseAnimationNameProp(decl)).toMatchInlineSnapshot(`
-    	{
-    	  "diagnostics": [
-    	    {
-    	      "category": "error",
-    	      "length": 14,
-    	      "start": {
-    	        "column": 5,
-    	        "line": 5,
-    	      },
-    	      "text": "\`local(...)\` must contain exactly one identifier.",
-    	    },
-    	  ],
-    	  "references": [
-    	    {
-    	      "loc": {
-    	        "end": {
-    	          "column": 8,
-    	          "line": 3,
-    	          "offset": 32,
-    	        },
-    	        "start": {
-    	          "column": 5,
-    	          "line": 3,
-    	          "offset": 29,
-    	        },
-    	      },
-    	      "name": "a_2",
-    	    },
-    	    {
-    	      "loc": {
-    	        "end": {
-    	          "column": 14,
-    	          "line": 4,
-    	          "offset": 47,
-    	        },
-    	        "start": {
-    	          "column": 11,
-    	          "line": 4,
-    	          "offset": 44,
-    	        },
-    	      },
-    	      "name": "a_3",
-    	    },
-    	  ],
-    	}
+      {
+        "diagnostics": [
+          {
+            "category": "error",
+            "length": 14,
+            "start": {
+              "column": 5,
+              "line": 5,
+            },
+            "text": "\`local(...)\` must contain exactly one identifier.",
+          },
+        ],
+        "references": [
+          {
+            "loc": {
+              "end": {
+                "column": 8,
+                "line": 3,
+                "offset": 32,
+              },
+              "start": {
+                "column": 5,
+                "line": 3,
+                "offset": 29,
+              },
+            },
+            "name": "a_2",
+            "type": "local",
+          },
+          {
+            "loc": {
+              "end": {
+                "column": 14,
+                "line": 4,
+                "offset": 47,
+              },
+              "start": {
+                "column": 11,
+                "line": 4,
+                "offset": 44,
+              },
+            },
+            "name": "a_3",
+            "type": "local",
+          },
+        ],
+      }
     `);
   });
 });

--- a/packages/core/src/parser/animation-parser.ts
+++ b/packages/core/src/parser/animation-parser.ts
@@ -31,6 +31,7 @@ export function parseAnimationNameProp(decl: Declaration): ParseAnimationResult 
         continue;
       }
       references.push({
+        type: 'local',
         name: nameNodeOrError.value,
         loc: calcDeclValueLoc(decl, nameNodeOrError.sourceIndex, nameNodeOrError.value.length),
       });
@@ -38,7 +39,11 @@ export function parseAnimationNameProp(decl: Declaration): ParseAnimationResult 
     }
     if (node.type !== 'word') continue;
     if (COMMON_RESERVED_KEYWORDS.has(node.value.toLowerCase())) continue;
-    references.push({ name: node.value, loc: calcDeclValueLoc(decl, node.sourceIndex, node.value.length) });
+    references.push({
+      type: 'local',
+      name: node.value,
+      loc: calcDeclValueLoc(decl, node.sourceIndex, node.value.length),
+    });
   }
   return { references, diagnostics };
 }

--- a/packages/core/src/parser/composes-parser.test.ts
+++ b/packages/core/src/parser/composes-parser.test.ts
@@ -18,220 +18,383 @@ describe('isComposesProp', () => {
 });
 
 describe('parseComposesProp', () => {
-  test('extracts a single class name', () => {
+  test('extracts a local reference from a single class name', () => {
     const decl = fakeDeclaration('.a_1 { composes: a_2 }');
     expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
-      {
-        "diagnostics": [],
-        "references": [
-          {
-            "loc": {
-              "end": {
-                "column": 21,
-                "line": 1,
-                "offset": 20,
-              },
-              "start": {
-                "column": 18,
-                "line": 1,
-                "offset": 17,
-              },
+      [
+        {
+          "loc": {
+            "end": {
+              "column": 21,
+              "line": 1,
+              "offset": 20,
             },
-            "name": "a_2",
+            "start": {
+              "column": 18,
+              "line": 1,
+              "offset": 17,
+            },
           },
-        ],
-      }
+          "name": "a_2",
+          "type": "local",
+        },
+      ]
     `);
   });
 
-  test('extracts space-separated class names', () => {
+  test('extracts a local reference for each space-separated class name', () => {
     const decl = fakeDeclaration('.a_1 { composes: a_2 a_3 }');
     expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
-      {
-        "diagnostics": [],
-        "references": [
-          {
-            "loc": {
-              "end": {
-                "column": 21,
-                "line": 1,
-                "offset": 20,
-              },
-              "start": {
-                "column": 18,
-                "line": 1,
-                "offset": 17,
-              },
+      [
+        {
+          "loc": {
+            "end": {
+              "column": 21,
+              "line": 1,
+              "offset": 20,
             },
-            "name": "a_2",
-          },
-          {
-            "loc": {
-              "end": {
-                "column": 25,
-                "line": 1,
-                "offset": 24,
-              },
-              "start": {
-                "column": 22,
-                "line": 1,
-                "offset": 21,
-              },
+            "start": {
+              "column": 18,
+              "line": 1,
+              "offset": 17,
             },
-            "name": "a_3",
           },
-        ],
-      }
+          "name": "a_2",
+          "type": "local",
+        },
+        {
+          "loc": {
+            "end": {
+              "column": 25,
+              "line": 1,
+              "offset": 24,
+            },
+            "start": {
+              "column": 22,
+              "line": 1,
+              "offset": 21,
+            },
+          },
+          "name": "a_3",
+          "type": "local",
+        },
+      ]
     `);
   });
 
-  test('extracts comma-separated class names', () => {
+  test('extracts a local reference for each comma-separated class name', () => {
     const decl = fakeDeclaration('.a_1 { composes: a_2, a_3 }');
     expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
-      {
-        "diagnostics": [],
-        "references": [
-          {
-            "loc": {
-              "end": {
-                "column": 21,
-                "line": 1,
-                "offset": 20,
-              },
-              "start": {
-                "column": 18,
-                "line": 1,
-                "offset": 17,
-              },
+      [
+        {
+          "loc": {
+            "end": {
+              "column": 21,
+              "line": 1,
+              "offset": 20,
             },
-            "name": "a_2",
-          },
-          {
-            "loc": {
-              "end": {
-                "column": 26,
-                "line": 1,
-                "offset": 25,
-              },
-              "start": {
-                "column": 23,
-                "line": 1,
-                "offset": 22,
-              },
+            "start": {
+              "column": 18,
+              "line": 1,
+              "offset": 17,
             },
-            "name": "a_3",
           },
-        ],
-      }
+          "name": "a_2",
+          "type": "local",
+        },
+        {
+          "loc": {
+            "end": {
+              "column": 26,
+              "line": 1,
+              "offset": 25,
+            },
+            "start": {
+              "column": 23,
+              "line": 1,
+              "offset": 22,
+            },
+          },
+          "name": "a_3",
+          "type": "local",
+        },
+      ]
     `);
   });
 
   test('skips class name inside global()', () => {
     const decl = fakeDeclaration('.a_1 { composes: global(a_2) }');
-    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
-      {
-        "diagnostics": [],
-        "references": [],
-      }
-    `);
+    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`[]`);
   });
 
-  test('skips items with from global', () => {
+  test('skips items with `from global`', () => {
     const decl = fakeDeclaration('.a_1 { composes: a_2 a_3 from global }');
-    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
-      {
-        "diagnostics": [],
-        "references": [],
-      }
-    `);
+    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`[]`);
   });
 
-  test('skips items with from specifier', () => {
+  test('extracts an external reference from an item with a `from` specifier', () => {
     const decl = fakeDeclaration(`.a_1 { composes: a_2 from './a.module.css' }`);
     expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
-      {
-        "diagnostics": [],
-        "references": [],
-      }
+      [
+        {
+          "entries": [
+            {
+              "loc": {
+                "end": {
+                  "column": 21,
+                  "line": 1,
+                  "offset": 20,
+                },
+                "start": {
+                  "column": 18,
+                  "line": 1,
+                  "offset": 17,
+                },
+              },
+              "name": "a_2",
+            },
+          ],
+          "from": "./a.module.css",
+          "fromLoc": {
+            "end": {
+              "column": 42,
+              "line": 1,
+              "offset": 41,
+            },
+            "start": {
+              "column": 28,
+              "line": 1,
+              "offset": 27,
+            },
+          },
+          "type": "external",
+        },
+      ]
     `);
   });
 
-  test('extracts class names only from items without a from clause', () => {
+  test('extracts an external reference with an entry for each class name', () => {
+    const decl = fakeDeclaration(`.a_1 { composes: a_2 a_3 from './a.module.css' }`);
+    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
+      [
+        {
+          "entries": [
+            {
+              "loc": {
+                "end": {
+                  "column": 21,
+                  "line": 1,
+                  "offset": 20,
+                },
+                "start": {
+                  "column": 18,
+                  "line": 1,
+                  "offset": 17,
+                },
+              },
+              "name": "a_2",
+            },
+            {
+              "loc": {
+                "end": {
+                  "column": 25,
+                  "line": 1,
+                  "offset": 24,
+                },
+                "start": {
+                  "column": 22,
+                  "line": 1,
+                  "offset": 21,
+                },
+              },
+              "name": "a_3",
+            },
+          ],
+          "from": "./a.module.css",
+          "fromLoc": {
+            "end": {
+              "column": 46,
+              "line": 1,
+              "offset": 45,
+            },
+            "start": {
+              "column": 32,
+              "line": 1,
+              "offset": 31,
+            },
+          },
+          "type": "external",
+        },
+      ]
+    `);
+  });
+
+  test('extracts local and external references according to the `from` clause of each item', () => {
     const decl = fakeDeclaration(`.a_1 { composes: a_2, a_3 from './a.module.css', a_4 from global, a_5 }`);
     expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
-      {
-        "diagnostics": [],
-        "references": [
-          {
-            "loc": {
-              "end": {
-                "column": 21,
-                "line": 1,
-                "offset": 20,
-              },
-              "start": {
-                "column": 18,
-                "line": 1,
-                "offset": 17,
-              },
+      [
+        {
+          "loc": {
+            "end": {
+              "column": 21,
+              "line": 1,
+              "offset": 20,
             },
-            "name": "a_2",
-          },
-          {
-            "loc": {
-              "end": {
-                "column": 70,
-                "line": 1,
-                "offset": 69,
-              },
-              "start": {
-                "column": 67,
-                "line": 1,
-                "offset": 66,
-              },
+            "start": {
+              "column": 18,
+              "line": 1,
+              "offset": 17,
             },
-            "name": "a_5",
           },
-        ],
-      }
+          "name": "a_2",
+          "type": "local",
+        },
+        {
+          "entries": [
+            {
+              "loc": {
+                "end": {
+                  "column": 26,
+                  "line": 1,
+                  "offset": 25,
+                },
+                "start": {
+                  "column": 23,
+                  "line": 1,
+                  "offset": 22,
+                },
+              },
+              "name": "a_3",
+            },
+          ],
+          "from": "./a.module.css",
+          "fromLoc": {
+            "end": {
+              "column": 47,
+              "line": 1,
+              "offset": 46,
+            },
+            "start": {
+              "column": 33,
+              "line": 1,
+              "offset": 32,
+            },
+          },
+          "type": "external",
+        },
+        {
+          "loc": {
+            "end": {
+              "column": 70,
+              "line": 1,
+              "offset": 69,
+            },
+            "start": {
+              "column": 67,
+              "line": 1,
+              "offset": 66,
+            },
+          },
+          "name": "a_5",
+          "type": "local",
+        },
+      ]
     `);
   });
 
-  test('reports a diagnostic for from clause without quoted specifier or global keyword (unquoted specifier, empty, non-global word)', () => {
-    const decl = fakeDeclaration('.a_1 { composes: a_2 from ./a.module.css, a_3 from, a_4 from b_1 }');
+  test('extracts local references from an item where `from` is not preceded by class names', () => {
+    const decl = fakeDeclaration('.a_1 { composes: from global }');
     expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
-      {
-        "diagnostics": [
-          {
-            "category": "error",
-            "length": 19,
+      [
+        {
+          "loc": {
+            "end": {
+              "column": 22,
+              "line": 1,
+              "offset": 21,
+            },
+            "start": {
+              "column": 18,
+              "line": 1,
+              "offset": 17,
+            },
+          },
+          "name": "from",
+          "type": "local",
+        },
+        {
+          "loc": {
+            "end": {
+              "column": 29,
+              "line": 1,
+              "offset": 28,
+            },
+            "start": {
+              "column": 23,
+              "line": 1,
+              "offset": 22,
+            },
+          },
+          "name": "global",
+          "type": "local",
+        },
+      ]
+    `);
+  });
+
+  test('extracts local references from an item whose `from` clause is invalid', () => {
+    const decl = fakeDeclaration('.a_1 { composes: a_2 from a_3 }');
+    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
+      [
+        {
+          "loc": {
+            "end": {
+              "column": 21,
+              "line": 1,
+              "offset": 20,
+            },
+            "start": {
+              "column": 18,
+              "line": 1,
+              "offset": 17,
+            },
+          },
+          "name": "a_2",
+          "type": "local",
+        },
+        {
+          "loc": {
+            "end": {
+              "column": 26,
+              "line": 1,
+              "offset": 25,
+            },
             "start": {
               "column": 22,
               "line": 1,
+              "offset": 21,
             },
-            "text": "\`from\` must be followed by a quoted specifier or \`global\`.",
           },
-          {
-            "category": "error",
-            "length": 4,
-            "start": {
-              "column": 47,
+          "name": "from",
+          "type": "local",
+        },
+        {
+          "loc": {
+            "end": {
+              "column": 30,
               "line": 1,
+              "offset": 29,
             },
-            "text": "\`from\` must be followed by a quoted specifier or \`global\`.",
-          },
-          {
-            "category": "error",
-            "length": 8,
             "start": {
-              "column": 57,
+              "column": 27,
               "line": 1,
+              "offset": 26,
             },
-            "text": "\`from\` must be followed by a quoted specifier or \`global\`.",
           },
-        ],
-        "references": [],
-      }
+          "name": "a_3",
+          "type": "local",
+        },
+      ]
     `);
   });
 
@@ -245,41 +408,40 @@ describe('parseComposesProp', () => {
       }
     `);
     expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
-      {
-        "diagnostics": [],
-        "references": [
-          {
-            "loc": {
-              "end": {
-                "column": 8,
-                "line": 3,
-                "offset": 26,
-              },
-              "start": {
-                "column": 5,
-                "line": 3,
-                "offset": 23,
-              },
+      [
+        {
+          "loc": {
+            "end": {
+              "column": 8,
+              "line": 3,
+              "offset": 26,
             },
-            "name": "a_2",
-          },
-          {
-            "loc": {
-              "end": {
-                "column": 8,
-                "line": 5,
-                "offset": 56,
-              },
-              "start": {
-                "column": 5,
-                "line": 5,
-                "offset": 53,
-              },
+            "start": {
+              "column": 5,
+              "line": 3,
+              "offset": 23,
             },
-            "name": "a_4",
           },
-        ],
-      }
+          "name": "a_2",
+          "type": "local",
+        },
+        {
+          "loc": {
+            "end": {
+              "column": 8,
+              "line": 5,
+              "offset": 56,
+            },
+            "start": {
+              "column": 5,
+              "line": 5,
+              "offset": 53,
+            },
+          },
+          "name": "a_4",
+          "type": "local",
+        },
+      ]
     `);
   });
 });

--- a/packages/core/src/parser/composes-parser.ts
+++ b/packages/core/src/parser/composes-parser.ts
@@ -1,6 +1,11 @@
 import type { Declaration } from 'postcss';
 import postcssValueParser from 'postcss-value-parser';
-import type { DiagnosticWithDetachedLocation, TokenReference } from '../type.js';
+import type {
+  ExternalTokenReference,
+  ExternalTokenReferenceEntry,
+  LocalTokenReference,
+  TokenReference,
+} from '../type.js';
 import { calcDeclValueLoc } from './decl-value-location.js';
 
 const COMPOSES_PROP_RE = /^composes$/iu;
@@ -9,31 +14,81 @@ export function isComposesProp(prop: string): boolean {
   return COMPOSES_PROP_RE.test(prop);
 }
 
-interface ParseComposesResult {
-  references: TokenReference[];
-  diagnostics: DiagnosticWithDetachedLocation[];
-}
-
 /** Parse a `composes` declaration and extract token references. */
-export function parseComposesProp(decl: Declaration): ParseComposesResult {
+export function parseComposesProp(decl: Declaration): TokenReference[] {
   const references: TokenReference[] = [];
-  const diagnostics: DiagnosticWithDetachedLocation[] = [];
   for (const item of splitByComma(postcssValueParser(decl.value).nodes)) {
-    const fromIndex = item.findLastIndex((node) => node.type === 'word' && node.value === 'from');
-    if (fromIndex === -1) {
-      for (const node of item) {
-        // `global(name)` and any other function are skipped.
-        if (node.type !== 'word') continue;
-        references.push({ name: node.value, loc: calcDeclValueLoc(decl, node.sourceIndex, node.value.length) });
-      }
+    if (hasFromClause(item)) {
+      const specifierNode = item.at(-1)!;
+      // Items with `from global` do not produce token references.
+      if (specifierNode.type !== 'string') continue;
+      const head = item.slice(0, findFromKeywordIndex(item));
+      const externalReference = createExternalReference(decl, head, specifierNode);
+      if (externalReference.entries.length > 0) references.push(externalReference);
       continue;
     }
-    if (!isValidFromClauseTail(item.slice(fromIndex + 1))) {
-      diagnostics.push(createInvalidFromClauseDiagnostic(decl, item, fromIndex));
-    }
-    // Items with `from global` and `from '<specifier>'` do not produce local token references.
+    // Items without a `from` clause consist of plain class names.
+    references.push(...createLocalReferences(decl, item));
   }
-  return { references, diagnostics };
+  return references;
+}
+
+/**
+ * Check that the item forms a `from` clause: one or more nodes followed by `from`
+ * and a quoted specifier (e.g. `'./a.module.css'`) or the keyword `global`.
+ */
+function hasFromClause(item: postcssValueParser.Node[]): boolean {
+  const fromIndex = findFromKeywordIndex(item);
+  return fromIndex >= 1 && isValidFromClauseTail(item.slice(fromIndex + 1));
+}
+
+function findFromKeywordIndex(item: postcssValueParser.Node[]): number {
+  return item.findLastIndex((node) => node.type === 'word' && node.value === 'from');
+}
+
+/**
+ * Check that the nodes after `from` represent a valid import source: a single
+ * quoted specifier (e.g. `'./a.module.css'`) or the keyword `global`.
+ */
+function isValidFromClauseTail(tail: postcssValueParser.Node[]): boolean {
+  if (tail.length !== 1) return false;
+  const node = tail[0]!;
+  return node.type === 'string' || (node.type === 'word' && node.value === 'global');
+}
+
+/** Create a local token reference for each class name in `nodes`. */
+function createLocalReferences(decl: Declaration, nodes: postcssValueParser.Node[]): LocalTokenReference[] {
+  const references: LocalTokenReference[] = [];
+  for (const node of nodes) {
+    // `global(name)` and any other function are skipped.
+    if (node.type !== 'word') continue;
+    references.push({
+      type: 'local',
+      name: node.value,
+      loc: calcDeclValueLoc(decl, node.sourceIndex, node.value.length),
+    });
+  }
+  return references;
+}
+
+/** Create an external token reference with an entry for each class name in `nodes`. */
+function createExternalReference(
+  decl: Declaration,
+  nodes: postcssValueParser.Node[],
+  specifierNode: postcssValueParser.StringNode,
+): ExternalTokenReference {
+  const entries: ExternalTokenReferenceEntry[] = [];
+  for (const node of nodes) {
+    if (node.type !== 'word') continue;
+    entries.push({ name: node.value, loc: calcDeclValueLoc(decl, node.sourceIndex, node.value.length) });
+  }
+  return {
+    type: 'external',
+    entries,
+    from: specifierNode.value,
+    // The location of the specifier without quotes.
+    fromLoc: calcDeclValueLoc(decl, specifierNode.sourceIndex + 1, specifierNode.value.length),
+  };
 }
 
 /** Split the value nodes by top-level commas. Space nodes are dropped. */
@@ -47,31 +102,4 @@ function splitByComma(nodes: postcssValueParser.Node[]): postcssValueParser.Node
     }
   }
   return items;
-}
-
-/**
- * Check that the nodes after `from` represent a valid import source: a single
- * quoted specifier (e.g. `'./a.module.css'`) or the keyword `global`.
- */
-function isValidFromClauseTail(tail: postcssValueParser.Node[]): boolean {
-  if (tail.length !== 1) return false;
-  const node = tail[0]!;
-  return node.type === 'string' || (node.type === 'word' && node.value === 'global');
-}
-
-function createInvalidFromClauseDiagnostic(
-  decl: Declaration,
-  item: postcssValueParser.Node[],
-  fromIndex: number,
-): DiagnosticWithDetachedLocation {
-  const fromNode = item[fromIndex]!;
-  const lastNode = item[item.length - 1]!;
-  const length = lastNode.sourceEndIndex - fromNode.sourceIndex;
-  const { start } = calcDeclValueLoc(decl, fromNode.sourceIndex, length);
-  return {
-    text: '`from` must be followed by a quoted specifier or `global`.',
-    category: 'error',
-    start: { line: start.line, column: start.column },
-    length,
-  };
 }

--- a/packages/core/src/parser/css-module-parser.test.ts
+++ b/packages/core/src/parser/css-module-parser.test.ts
@@ -595,86 +595,87 @@ describe('parseCSSModule', () => {
       options,
     );
     expect(parsed).toMatchInlineSnapshot(`
-    	{
-    	  "diagnostics": [],
-    	  "fileName": "/test.module.css",
-    	  "localTokens": [
-    	    {
-    	      "declarationLoc": {
-    	        "end": {
-    	          "column": 18,
-    	          "line": 1,
-    	          "offset": 17,
-    	        },
-    	        "start": {
-    	          "column": 1,
-    	          "line": 1,
-    	          "offset": 0,
-    	        },
-    	      },
-    	      "loc": {
-    	        "end": {
-    	          "column": 15,
-    	          "line": 1,
-    	          "offset": 14,
-    	        },
-    	        "start": {
-    	          "column": 12,
-    	          "line": 1,
-    	          "offset": 11,
-    	        },
-    	      },
-    	      "name": "a_1",
-    	    },
-    	    {
-    	      "declarationLoc": {
-    	        "end": {
-    	          "column": 30,
-    	          "line": 2,
-    	          "offset": 47,
-    	        },
-    	        "start": {
-    	          "column": 1,
-    	          "line": 2,
-    	          "offset": 18,
-    	        },
-    	      },
-    	      "loc": {
-    	        "end": {
-    	          "column": 5,
-    	          "line": 2,
-    	          "offset": 22,
-    	        },
-    	        "start": {
-    	          "column": 2,
-    	          "line": 2,
-    	          "offset": 19,
-    	        },
-    	      },
-    	      "name": "a_2",
-    	    },
-    	  ],
-    	  "text": "@keyframes a_1 {}
-    	.a_2 { animation-name: a_1; }",
-    	  "tokenImporters": [],
-    	  "tokenReferences": [
-    	    {
-    	      "loc": {
-    	        "end": {
-    	          "column": 27,
-    	          "line": 2,
-    	          "offset": 44,
-    	        },
-    	        "start": {
-    	          "column": 24,
-    	          "line": 2,
-    	          "offset": 41,
-    	        },
-    	      },
-    	      "name": "a_1",
-    	    },
-    	  ],
-    	}
+      {
+        "diagnostics": [],
+        "fileName": "/test.module.css",
+        "localTokens": [
+          {
+            "declarationLoc": {
+              "end": {
+                "column": 18,
+                "line": 1,
+                "offset": 17,
+              },
+              "start": {
+                "column": 1,
+                "line": 1,
+                "offset": 0,
+              },
+            },
+            "loc": {
+              "end": {
+                "column": 15,
+                "line": 1,
+                "offset": 14,
+              },
+              "start": {
+                "column": 12,
+                "line": 1,
+                "offset": 11,
+              },
+            },
+            "name": "a_1",
+          },
+          {
+            "declarationLoc": {
+              "end": {
+                "column": 30,
+                "line": 2,
+                "offset": 47,
+              },
+              "start": {
+                "column": 1,
+                "line": 2,
+                "offset": 18,
+              },
+            },
+            "loc": {
+              "end": {
+                "column": 5,
+                "line": 2,
+                "offset": 22,
+              },
+              "start": {
+                "column": 2,
+                "line": 2,
+                "offset": 19,
+              },
+            },
+            "name": "a_2",
+          },
+        ],
+        "text": "@keyframes a_1 {}
+      .a_2 { animation-name: a_1; }",
+        "tokenImporters": [],
+        "tokenReferences": [
+          {
+            "loc": {
+              "end": {
+                "column": 27,
+                "line": 2,
+                "offset": 44,
+              },
+              "start": {
+                "column": 24,
+                "line": 2,
+                "offset": 41,
+              },
+            },
+            "name": "a_1",
+            "type": "local",
+          },
+        ],
+      }
     `);
   });
   test('collects token references from composes declarations', () => {
@@ -701,6 +702,7 @@ describe('parseCSSModule', () => {
             },
           },
           "name": "a_1",
+          "type": "local",
         },
       ]
     `);

--- a/packages/core/src/parser/css-module-parser.ts
+++ b/packages/core/src/parser/css-module-parser.ts
@@ -85,9 +85,7 @@ function collectTokens(ast: Root, keyframes: boolean) {
       allDiagnostics.push(...diagnostics);
       tokenReferences.push(...references);
     } else if (isDeclarationNode(node) && isComposesProp(node.prop)) {
-      const { references, diagnostics } = parseComposesProp(node);
-      allDiagnostics.push(...diagnostics);
-      tokenReferences.push(...references);
+      tokenReferences.push(...parseComposesProp(node));
     }
   });
   return { localTokens, tokenImporters, tokenReferences, diagnostics: allDiagnostics };

--- a/packages/core/src/type.ts
+++ b/packages/core/src/type.ts
@@ -98,21 +98,54 @@ export interface NamedTokenImporterEntry {
 export type TokenImporter = AllTokenImporter | NamedTokenImporter;
 
 /**
- * A reference to a token from a CSS Module file.
+ * A reference to a token available in the current file.
  *
- * For example, `animation-name: foo;` references the `foo` token. The token
- * itself may be defined in the same file (e.g. by `@keyframes foo {...}`) or
- * imported from another file (e.g. via `@import`). Token references connect
- * the usage site to the declaration site so that language features (Go to
- * Definition, Find All References, Rename) work consistently across
- * `@keyframes` definitions and `animation-name` references.
+ * For example, `animation-name: foo;` and `composes: foo;` reference the
+ * `foo` token. The token itself may be defined in the same file (e.g. by
+ * `@keyframes foo {...}`) or imported from another file (e.g. via `@import`).
  */
-export interface TokenReference {
+export interface LocalTokenReference {
+  type: 'local';
   /** The referenced token name. */
   name: string;
   /** The location of the reference name in the source file. */
   loc: Location;
 }
+
+/**
+ * A reference to tokens exported by another CSS Module file.
+ * @example `composes: foo bar from './a.module.css'` references the `foo` and `bar` tokens of `./a.module.css`.
+ */
+export interface ExternalTokenReference {
+  type: 'external';
+  /** The entries describing each referenced token. */
+  entries: ExternalTokenReferenceEntry[];
+  /**
+   * The specifier of the file from which the tokens are referenced.
+   * This is a string before being resolved and unquoted.
+   * @example `composes: foo from './a.module.css'` would have `from` as `'./a.module.css'`.
+   */
+  from: string;
+  /** The location of the `from` in *.module.css file. */
+  fromLoc: Location;
+}
+
+/** A single token referenced by an {@link ExternalTokenReference}. */
+export interface ExternalTokenReferenceEntry {
+  /** The referenced token name. */
+  name: string;
+  /** The location of the reference name in the source file. */
+  loc: Location;
+}
+
+/**
+ * A reference to a token from a CSS Module file.
+ *
+ * Token references connect the usage site to the declaration site so that
+ * language features (Go to Definition, Find All References, Rename) work
+ * consistently across token definitions and their usages.
+ */
+export type TokenReference = LocalTokenReference | ExternalTokenReference;
 
 export interface CSSModule {
   /** Absolute path of the file */

--- a/packages/core/src/util.test.ts
+++ b/packages/core/src/util.test.ts
@@ -50,4 +50,8 @@ describe('findUsedTokenNames', () => {
     const root = fakeRoot('.a_3 { composes: a_1 a_2; }');
     expect(findUsedTokenNames('styles.a_3;', root)).toEqual(new Set(['a_1', 'a_2', 'a_3']));
   });
+  test('does not collect token names referenced from composes with a `from` specifier', () => {
+    const root = fakeRoot(`.a_2 { composes: a_1 from './b.module.css'; }`);
+    expect(findUsedTokenNames('styles.a_2;', root)).toEqual(new Set(['a_2']));
+  });
 });

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -58,11 +58,14 @@ export function findUsedTokenNames(componentText: string, root: Root): Set<strin
     if (isAnimationNameProp(decl.prop)) {
       ({ references } = parseAnimationNameProp(decl));
     } else if (isComposesProp(decl.prop)) {
-      ({ references } = parseComposesProp(decl));
+      references = parseComposesProp(decl);
     } else {
       return;
     }
     for (const reference of references) {
+      // External references point to tokens of another file, so they do not
+      // mark same-named tokens of the current file as used.
+      if (reference.type !== 'local') continue;
       usedClassNames.add(reference.name);
     }
   });

--- a/packages/ts-plugin/e2e-test/find-all-references.test.ts
+++ b/packages/ts-plugin/e2e-test/find-all-references.test.ts
@@ -290,7 +290,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
   });
 
-  describe('for a token reference', () => {
+  describe('for a local token reference', () => {
     test('from a token definition', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
@@ -316,7 +316,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from a token reference', async () => {
+    test('from a local token reference', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': dedent`
@@ -337,6 +337,29 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
           { file: formatPath(iff.paths['a.module.css']), ...getRange('a.module.css', 'a_1', 0) },
           { file: formatPath(iff.paths['a.module.css']), ...getRange('a.module.css', 'a_1', 1) },
           { file: formatPath(iff.paths['a.module.css']), ...getRange('a.module.css', 'a_1', 2) },
+        ]),
+      );
+    });
+  });
+
+  describe('for an external token reference', () => {
+    test('from an external token reference', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': `.a_1 { composes: b_1 from './b.module.css'; }`,
+        'b.module.css': `.b_1 { color: red; }`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendReferences({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'b_1'),
+      });
+
+      expect(normalizeRefItems(res.body?.refs ?? [])).toStrictEqual(
+        normalizeRefItems([
+          { file: formatPath(iff.paths['a.module.css']), ...getRange('a.module.css', 'b_1') },
+          { file: formatPath(iff.paths['b.module.css']), ...getRange('b.module.css', 'b_1') },
         ]),
       );
     });

--- a/packages/ts-plugin/e2e-test/go-to-definition.test.ts
+++ b/packages/ts-plugin/e2e-test/go-to-definition.test.ts
@@ -433,8 +433,8 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
   });
 
-  describe('for a token reference', () => {
-    test('from a token reference', async () => {
+  describe('for a local token reference', () => {
+    test('from a local token reference', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': dedent`
@@ -462,7 +462,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from each <name> in a multi-value token reference', async () => {
+    test('from each <name> in a multi-value local token reference', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': dedent`
@@ -506,7 +506,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from a kebab-case token reference', async () => {
+    test('from a kebab-case local token reference', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': dedent`
@@ -534,7 +534,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from a token reference whose target is imported', async () => {
+    test('from a local token reference whose target is imported', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': dedent`
@@ -551,6 +551,34 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       });
 
       const { start: contextStart, end: contextEnd } = getRange('b.module.css', '@keyframes b_1 { from {} to {} }');
+      expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
+        normalizeDefinitions([
+          {
+            file: formatPath(iff.paths['b.module.css']),
+            ...getRange('b.module.css', 'b_1'),
+            contextStart,
+            contextEnd,
+          },
+        ]),
+      );
+    });
+  });
+
+  describe('for an external token reference', () => {
+    test('from an external token reference', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': `.a_1 { composes: b_1 from './b.module.css'; }`,
+        'b.module.css': `.b_1 { color: red; }`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendDefinitionAndBoundSpan({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'b_1'),
+      });
+
+      const { start: contextStart, end: contextEnd } = getRange('b.module.css', '.b_1 { color: red; }');
       expect(normalizeDefinitions(res.body?.definitions ?? [])).toStrictEqual(
         normalizeDefinitions([
           {

--- a/packages/ts-plugin/e2e-test/rename-symbol.test.ts
+++ b/packages/ts-plugin/e2e-test/rename-symbol.test.ts
@@ -270,7 +270,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
     });
   });
 
-  describe('for a token reference', () => {
+  describe('for a local token reference', () => {
     test('from a token definition', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
@@ -301,7 +301,7 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
       );
     });
 
-    test('from a token reference', async () => {
+    test('from a local token reference', async () => {
       const { iff, getLoc, getRange } = await setupFixture({
         'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
         'a.module.css': dedent`
@@ -327,6 +327,29 @@ describe.each([{ namedExports: false }, { namedExports: true }])('namedExports: 
               getRange('a.module.css', 'a_1', 2),
             ],
           },
+        ]),
+      );
+    });
+  });
+
+  describe('for an external token reference', () => {
+    test('from an external token reference', async () => {
+      const { iff, getLoc, getRange } = await setupFixture({
+        'tsconfig.json': buildTSConfigJSON({ cmkOptions: { namedExports } }),
+        'a.module.css': `.a_1 { composes: b_1 from './b.module.css'; }`,
+        'b.module.css': `.b_1 { color: red; }`,
+      });
+      await tsserver.sendUpdateOpen({ openFiles: [{ file: iff.paths['a.module.css'] }] });
+
+      const res = await tsserver.sendRename({
+        file: iff.paths['a.module.css'],
+        ...getLoc('a.module.css', 'b_1'),
+      });
+
+      expect(normalizeSpanGroups(res.body?.locs ?? [])).toStrictEqual(
+        normalizeSpanGroups([
+          { file: formatPath(iff.paths['a.module.css']), locs: [getRange('a.module.css', 'b_1')] },
+          { file: formatPath(iff.paths['b.module.css']), locs: [getRange('b.module.css', 'b_1')] },
         ]),
       );
     });


### PR DESCRIPTION
close: #255

Part 2 of `composes` support, following #408. This PR adds support for the `composes: <name> from '<specifier>'` syntax.

## Changes

- Go to Definition / Find All References / Rename now work on class names referenced with `composes: <name> from '<specifier>'`
- The checker reports diagnostics for `composes` with a `from` specifier:
  - `Cannot import module '...'` when the specifier cannot be resolved. Unlike `@import`, URL specifiers are also reported, because css-loader fails to resolve them in `composes`
  - `Module '...' has no exported token '...'` when the referenced token is not exported by the specified file
- Items that do not match the form `<class names> from <quoted specifier | global>` (e.g. `composes: a_1 from a_2;`) are now treated as plain class names, following css-loader's behavior

## How to verify

1. Run `vp run build`
2. Open `examples/1-basic` in VS Code with the extension
3. In `src/a.module.css`, invoke Go to Definition / Find All References / Rename on `b_1` in `composes: a_1, b_1 from './b.module.css';`

https://github.com/user-attachments/assets/58a258d0-fcec-4311-a3d2-e66deb2f36ef

🤖 Generated with [Claude Code](https://claude.com/claude-code)