### PR TITLE
refactor(core): parse @value with postcss-value-parser

### DIFF
--- a/.changeset/at-value-parser-with-value-parser.md
+++ b/.changeset/at-value-parser-with-value-parser.md
@@ -1,0 +1,12 @@
+---
+'@css-modules-kit/core': minor
+---
+
+refactor(core): parse `@value` with postcss-value-parser
+
+The `@value` parser is reimplemented on top of postcss-value-parser. Behavior for syntax supported by css-loader is unchanged.
+
+For syntax that css-loader does not support (where css-modules-kit does not guarantee a specific behavior), the result changed:
+
+- `@value \\c: #000;` and `@value \'d: #000;` are now parsed as a token declaration instead of reporting an error.
+- `@value \31 e: #000;` is now read as the token name `\31` instead of `e`.

--- a/packages/core/src/parser/at-value-parser.test.ts
+++ b/packages/core/src/parser/at-value-parser.test.ts
@@ -4,7 +4,7 @@ import { fakeAtValues, fakeRoot } from '../test/ast.js';
 import { parseAtValue } from './at-value-parser.js';
 
 describe('parseAtValue', () => {
-  test('valid', () => {
+  test('parses syntax supported by css-loader', () => {
     const atValues = fakeAtValues(
       fakeRoot(dedent`
         @value basic: #000;
@@ -411,10 +411,14 @@ describe('parseAtValue', () => {
       ]
     `);
   });
-  test('invalid', () => {
-    // NOTE: These test cases are invalid as the syntax of @value. The behavior when using
-    // these syntaxes is undefined. A diagnostic like "`@value` is a invalid syntax." may
-    // or may not be reported.
+  test('parses syntax unsupported by css-loader', () => {
+    // NOTE: These syntaxes are not supported by css-loader, so css-modules-kit does not
+    // guarantee any specific behavior for them. The snapshots below document how the current
+    // implementation parses them rather than a behavior we commit to.
+    //
+    // The `@value \31 e` case is tokenized as `\31` and `e` instead of a single ident `1e`,
+    // because postcss-value-parser does not interpret CSS escape sequences in identifiers.
+    // This is a known bug: https://github.com/postcss/postcss-value-parser/issues/64
     const atValues = fakeAtValues(
       fakeRoot(dedent`
         @value;
@@ -494,7 +498,7 @@ describe('parseAtValue', () => {
               "category": "error",
               "length": 0,
               "start": {
-                "column": 8,
+                "column": 10,
                 "line": 2,
               },
               "text": "\`\` is invalid syntax.",
@@ -502,30 +506,66 @@ describe('parseAtValue', () => {
           ],
         },
         {
-          "diagnostics": [
-            {
-              "category": "error",
-              "length": 17,
+          "atValue": {
+            "declarationLoc": {
+              "end": {
+                "column": 17,
+                "line": 3,
+                "offset": 53,
+              },
               "start": {
                 "column": 1,
                 "line": 3,
+                "offset": 37,
               },
-              "text": "\`@value \\\\c: #000\` is a invalid syntax.",
             },
-          ],
+            "loc": {
+              "end": {
+                "column": 11,
+                "line": 3,
+                "offset": 47,
+              },
+              "start": {
+                "column": 8,
+                "line": 3,
+                "offset": 44,
+              },
+            },
+            "name": "\\\\c",
+            "type": "valueDeclaration",
+          },
+          "diagnostics": [],
         },
         {
-          "diagnostics": [
-            {
-              "category": "error",
-              "length": 17,
+          "atValue": {
+            "declarationLoc": {
+              "end": {
+                "column": 17,
+                "line": 4,
+                "offset": 71,
+              },
               "start": {
                 "column": 1,
                 "line": 4,
+                "offset": 55,
               },
-              "text": "\`@value \\'d: #000\` is a invalid syntax.",
             },
-          ],
+            "loc": {
+              "end": {
+                "column": 11,
+                "line": 4,
+                "offset": 65,
+              },
+              "start": {
+                "column": 8,
+                "line": 4,
+                "offset": 62,
+              },
+            },
+            "name": "\\'d",
+            "type": "valueDeclaration",
+          },
+          "diagnostics": [],
         },
         {
           "atValue": {
@@ -543,17 +583,17 @@ describe('parseAtValue', () => {
             },
             "loc": {
               "end": {
-                "column": 13,
+                "column": 11,
                 "line": 5,
-                "offset": 85,
+                "offset": 83,
               },
               "start": {
-                "column": 12,
+                "column": 8,
                 "line": 5,
-                "offset": 84,
+                "offset": 80,
               },
             },
-            "name": "e",
+            "name": "\\31",
             "type": "valueDeclaration",
           },
           "diagnostics": [],

--- a/packages/core/src/parser/at-value-parser.ts
+++ b/packages/core/src/parser/at-value-parser.ts
@@ -1,5 +1,6 @@
 import type { AtRule } from 'postcss';
-import type { DiagnosticPosition, DiagnosticWithDetachedLocation, Location } from '../type.js';
+import postcssValueParser from 'postcss-value-parser';
+import type { DiagnosticWithDetachedLocation, Location } from '../type.js';
 
 interface ValueDeclaration {
   type: 'valueDeclaration';
@@ -32,147 +33,135 @@ interface ParseAtValueResult {
   diagnostics: DiagnosticWithDetachedLocation[];
 }
 
-const VALUE_IMPORT_PATTERN = /^(.+?)\s+from\s+("[^"]*"|'[^']*')$/du;
-const VALUE_DEFINITION_PATTERN = /(?:\s+|^)([\w-]+):?(.*?)$/du;
-const IMPORTED_ITEM_PATTERN = /^([\w-]+)(?:\s+as\s+([\w-]+))?/du;
-
 /**
  * Parse the `@value` rule.
- * Forked from https://github.com/css-modules/postcss-modules-values/blob/v4.0.0/src/index.js.
  *
- * @license
- * ISC License (ISC)
- * Copyright (c) 2015, Glen Maddern
- *
- * Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted,
- * provided that the above copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING
- * ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
- * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
- * WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH
- * THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * MEMO: css-modules-kit does not support `@value` with parentheses (e.g., `@value (a, b) from '...';`) to simplify the implementation.
+ * MEMO: css-modules-kit does not support `@value` with variable module name (e.g., `@value a from moduleName;`) to simplify the implementation.
  */
-// MEMO: css-modules-kit does not support `@value` with parentheses (e.g., `@value (a, b) from '...';`) to simplify the implementation.
-// MEMO: css-modules-kit does not support `@value` with variable module name (e.g., `@value a from moduleName;`) to simplify the implementation.
 export function parseAtValue(atValue: AtRule): ParseAtValueResult {
-  const matchesForValueImport = atValue.params.match(VALUE_IMPORT_PATTERN);
+  const nodes = postcssValueParser(atValue.params).nodes;
+  if (isValueImport(nodes)) {
+    return parseValueImport(atValue, nodes);
+  }
+  return parseValueDeclaration(atValue, nodes);
+}
+
+/**
+ * Check that the params form a value import: one or more nodes followed by `from`
+ * and a single quoted specifier (e.g. `'./test.module.css'`).
+ */
+function isValueImport(nodes: postcssValueParser.Node[]): boolean {
+  const fromIndex = findFromKeywordIndex(nodes);
+  if (fromIndex < 1) return false;
+  const tail = nodes.slice(fromIndex + 1).filter((node) => node.type !== 'space');
+  return tail.length === 1 && tail[0]!.type === 'string';
+}
+
+function findFromKeywordIndex(nodes: postcssValueParser.Node[]): number {
+  return nodes.findLastIndex((node) => node.type === 'word' && node.value === 'from');
+}
+
+function parseValueImport(atValue: AtRule, nodes: postcssValueParser.Node[]): ParseAtValueResult {
+  const fromIndex = findFromKeywordIndex(nodes);
+  const specifierNode = nodes.slice(fromIndex + 1).find((node) => node.type === 'string')!;
+
+  const values: ValueImportDeclaration['values'] = [];
   const diagnostics: DiagnosticWithDetachedLocation[] = [];
-  if (matchesForValueImport) {
-    const [, importedItems, from] = matchesForValueImport as [string, string, string];
-    // The length of the `@value  ` part in `@value  import1 from '...'`
-    const baseLength = 6 + (atValue.raws.afterName?.length ?? 0);
-
-    let lastItemIndex = 0;
-    const values: ValueImportDeclaration['values'] = [];
-    for (const alias of importedItems.split(/\s*,\s*/u)) {
-      const currentItemIndex = importedItems.indexOf(alias, lastItemIndex);
-      lastItemIndex = currentItemIndex;
-      const matchesForImportedItem = alias.match(IMPORTED_ITEM_PATTERN);
-
-      if (matchesForImportedItem) {
-        const [, name, localName] = matchesForImportedItem as [string, string, string | undefined];
-        const nameIndex = matchesForImportedItem.indices![1]![0];
-        const start = {
-          line: atValue.source!.start!.line,
-          column: atValue.source!.start!.column + baseLength + currentItemIndex + nameIndex,
-          offset: atValue.source!.start!.offset + baseLength + currentItemIndex + nameIndex,
-        };
-        const end = {
-          line: start.line,
-          column: start.column + name.length,
-          offset: start.offset + name.length,
-        };
-        const result = { name, loc: { start, end } };
-        if (localName === undefined) {
-          values.push(result);
-        } else {
-          const localNameIndex = matchesForImportedItem.indices![2]![0];
-          const start = {
-            line: atValue.source!.start!.line,
-            column: atValue.source!.start!.column + baseLength + currentItemIndex + localNameIndex,
-            offset: atValue.source!.start!.offset + baseLength + currentItemIndex + localNameIndex,
-          };
-          const end = {
-            line: start.line,
-            column: start.column + localName.length,
-            offset: start.offset + localName.length,
-          };
-          values.push({ ...result, localName, localLoc: { start, end } });
-        }
-      } else {
-        const start: DiagnosticPosition = {
-          line: atValue.source!.start!.line,
-          column: atValue.source!.start!.column + baseLength + currentItemIndex,
-        };
-        diagnostics.push({
-          start,
-          length: alias.length,
-          text: `\`${alias}\` is invalid syntax.`,
-          category: 'error',
-        });
-      }
+  for (const item of splitByComma(nodes.slice(0, fromIndex))) {
+    const words = item.nodes.filter((node) => node.type === 'word');
+    const nameNode = words[0];
+    // An empty item (e.g. the middle item in `a,,b`) has no name, so report it like `@value;`.
+    if (nameNode === undefined) {
+      const { start } = calcAtValueParamsLoc(atValue, item.sourceIndex, 0);
+      diagnostics.push({
+        start: { line: start.line, column: start.column },
+        length: 0,
+        text: '`` is invalid syntax.',
+        category: 'error',
+      });
+      continue;
     }
-
-    // `from` is surrounded by quotes (e.g., `"./test.module.css"`). So, remove the quotes.
-    const normalizedFrom = from.slice(1, -1);
-
-    const fromIndex = matchesForValueImport.indices![2]![0] + 1;
-    const start = {
-      line: atValue.source!.start!.line,
-      column: atValue.source!.start!.column + baseLength + fromIndex,
-      offset: atValue.source!.start!.offset + baseLength + fromIndex,
+    const value: ValueImportDeclaration['values'][number] = {
+      name: nameNode.value,
+      loc: calcAtValueParamsLoc(atValue, nameNode.sourceIndex, nameNode.value.length),
     };
-    const end = {
-      line: start.line,
-      column: start.column + normalizedFrom.length,
-      offset: start.offset + normalizedFrom.length,
-    };
-
-    const parsedAtValue: ValueImportDeclaration = {
-      type: 'valueImportDeclaration',
-      values,
-      from: normalizedFrom,
-      fromLoc: { start, end },
-    };
-    return { atValue: parsedAtValue, diagnostics };
+    const localNode = words[1]?.value === 'as' ? words[2] : undefined;
+    if (localNode !== undefined) {
+      value.localName = localNode.value;
+      value.localLoc = calcAtValueParamsLoc(atValue, localNode.sourceIndex, localNode.value.length);
+    }
+    values.push(value);
   }
 
-  const matchesForValueDefinition = `${atValue.params}${atValue.raws.between!}`.match(VALUE_DEFINITION_PATTERN);
-  if (matchesForValueDefinition) {
-    const [, name, _value] = matchesForValueDefinition;
-    if (name === undefined) throw new Error(`unreachable`);
-    /** The index of the `<name>` in `@value <name>: <value>;`. */
-    const nameIndex = 6 + (atValue.raws.afterName?.length ?? 0) + matchesForValueDefinition.indices![1]![0];
-    const start = {
-      line: atValue.source!.start!.line,
-      column: atValue.source!.start!.column + nameIndex,
-      offset: atValue.source!.start!.offset + nameIndex,
+  const parsedAtValue: ValueImportDeclaration = {
+    type: 'valueImportDeclaration',
+    values,
+    from: specifierNode.value,
+    // The location of the specifier without quotes.
+    fromLoc: calcAtValueParamsLoc(atValue, specifierNode.sourceIndex + 1, specifierNode.value.length),
+  };
+  return { atValue: parsedAtValue, diagnostics };
+}
+
+function parseValueDeclaration(atValue: AtRule, nodes: postcssValueParser.Node[]): ParseAtValueResult {
+  const nameNode = nodes.find((node) => node.type !== 'space');
+  if (nameNode === undefined || nameNode.type !== 'word') {
+    return {
+      diagnostics: [
+        {
+          start: {
+            line: atValue.source!.start!.line,
+            column: atValue.source!.start!.column,
+          },
+          length: atValue.source!.end!.offset - atValue.source!.start!.offset,
+          text: `\`${atValue.toString()}\` is a invalid syntax.`,
+          category: 'error',
+        },
+      ],
     };
-    const end = {
-      line: start.line,
-      column: start.column + name.length,
-      offset: start.offset + name.length,
-    };
-    const parsedAtValue: ValueDeclaration = {
-      type: 'valueDeclaration',
-      name,
-      loc: { start, end },
-      declarationLoc: {
-        start: atValue.source!.start!,
-        end: atValue.positionBy({ index: atValue.toString().length }),
-      },
-    } as const;
-    return { atValue: parsedAtValue, diagnostics };
   }
-  diagnostics.push({
-    start: {
-      line: atValue.source!.start!.line,
-      column: atValue.source!.start!.column,
+  const parsedAtValue: ValueDeclaration = {
+    type: 'valueDeclaration',
+    name: nameNode.value,
+    loc: calcAtValueParamsLoc(atValue, nameNode.sourceIndex, nameNode.value.length),
+    declarationLoc: {
+      start: atValue.source!.start!,
+      end: atValue.positionBy({ index: atValue.toString().length }),
     },
-    length: atValue.source!.end!.offset - atValue.source!.start!.offset,
-    text: `\`${atValue.toString()}\` is a invalid syntax.`,
-    category: 'error',
-  });
-  return { diagnostics };
+  };
+  return { atValue: parsedAtValue, diagnostics: [] };
+}
+
+/**
+ * Calculate the location of a range in the params of an at-rule.
+ * @param sourceIndex The index of the range in the params.
+ * @param length The length of the range.
+ */
+function calcAtValueParamsLoc(atValue: AtRule, sourceIndex: number, length: number): Location {
+  const baseLength = 1 + atValue.name.length + (atValue.raws.afterName?.length ?? 0);
+  const startIndex = baseLength + sourceIndex;
+  return {
+    start: atValue.positionBy({ index: startIndex }),
+    end: atValue.positionBy({ index: startIndex + length }),
+  };
+}
+
+interface ImportItem {
+  nodes: postcssValueParser.Node[];
+  /** The source index where the item begins, used to locate an empty item. */
+  sourceIndex: number;
+}
+
+/** Split the nodes by top-level commas. Space nodes are dropped. */
+function splitByComma(nodes: postcssValueParser.Node[]): ImportItem[] {
+  const items: ImportItem[] = [{ nodes: [], sourceIndex: 0 }];
+  for (const node of nodes) {
+    if (node.type === 'div' && node.value === ',') {
+      items.push({ nodes: [], sourceIndex: node.sourceEndIndex });
+    } else if (node.type !== 'space') {
+      items.at(-1)!.nodes.push(node);
+    }
+  }
+  return items;
 }


### PR DESCRIPTION
## Why

The `@value` parser was built on three regular expressions plus manual `line`/`column`/`offset` arithmetic derived from the match indices, which was hard to follow and easy to get wrong. postcss-value-parser tokenizes the params and exposes each node's position directly, so it replaces both the regexes and the position math.

The result is a much simpler and more maintainable implementation: instead of crafting regexes and reconstructing positions by hand, we walk the parsed nodes and read their `sourceIndex` directly.

## Looking ahead

One motivation behind this change is to prepare for a possible future rewrite of the parser in Rust. The old regex-based code, with its hand-rolled position arithmetic, would have been awkward to port and easy to get subtly wrong. The new structure — walk the parsed tokens and read each node's position — maps cleanly onto a tokenizer-based implementation (e.g. with [`cssparser`](https://crates.io/crates/cssparser)), so it lays groundwork for that direction without committing to it yet.

## What

Reimplement `parseAtValue` on top of postcss-value-parser:

- The token name / import names / specifier locations are computed from each node's `sourceIndex` via a new `calcAtValueParamsLoc` helper.
- `declarationLoc` is still computed via `atValue.positionBy(...)`, independent of the value parser.

## Behavior changes

Behavior for **syntax supported by css-loader is unchanged** (snapshots, including all location info, are identical).

Changes are limited to **syntax css-loader does not support**, where css-modules-kit does not guarantee a specific behavior:

| Input | Before | After |
|---|---|---|
| `@value \\c: #000;` | reports `` `@value \c: #000` is a invalid syntax. `` | parsed as a token declaration named `\\\\c` (no diagnostic) |
| `@value \'d: #000;` | reports invalid syntax | parsed as a token declaration named `\\'d` (no diagnostic) |
| `@value \31 e: #000;` | token name `e` | parsed as a token declaration named `\\31` (no diagnostic) |
| `@value a,,b from "...";` | reports ` ` is invalid syntax. ` ` at column 8 | still reports it, now at column 10 (the empty item's actual position) |

These token names (`\\c` / `\'d` / `\31`) are invalid as JS export names and are rejected later by `isValidTokenName`, so generated `.d.ts` output is unaffected.

`@value \31 e` is split into `\31` and `e` because postcss-value-parser does not interpret CSS escape sequences in identifiers ([postcss-value-parser#64](https://github.com/postcss/postcss-value-parser/issues/64)); this is annotated in the test.

## How to verify

```
vp test packages/core/src/parser/at-value-parser.test.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)