### PR TITLE
refactor(core): tidy up @value/@import parser internals

### DIFF
--- a/packages/core/src/parser/at-import-parser.ts
+++ b/packages/core/src/parser/at-import-parser.ts
@@ -30,18 +30,13 @@ function convertParsedAtImport(
 ): ParsedAtImport {
   // The length of the `@import  ` part in `@import  '...'`
   const baseLength = 7 + (atImport.raws.afterName?.length ?? 0);
-  const start = {
-    line: atImport.source!.start!.line,
-    column: atImport.source!.start!.column + baseLength + node.sourceIndex + (node.type === 'string' ? 1 : 0),
-    offset: atImport.source!.start!.offset + baseLength + node.sourceIndex + (node.type === 'string' ? 1 : 0),
-  };
-  const end = {
-    line: start.line,
-    column: start.column + node.value.length,
-    offset: start.offset + node.value.length,
-  };
+  // For string nodes, skip the leading quote to point at the specifier itself.
+  const startIndex = baseLength + node.sourceIndex + (node.type === 'string' ? 1 : 0);
   return {
     from: node.value,
-    fromLoc: { start, end },
+    fromLoc: {
+      start: atImport.positionBy({ index: startIndex }),
+      end: atImport.positionBy({ index: startIndex + node.value.length }),
+    },
   };
 }

--- a/packages/core/src/parser/at-value-parser.test.ts
+++ b/packages/core/src/parser/at-value-parser.test.ts
@@ -49,7 +49,7 @@ describe('parseAtValue', () => {
               },
             },
             "name": "basic",
-            "type": "valueDeclaration",
+            "type": "declaration",
           },
           "diagnostics": [],
         },
@@ -80,7 +80,7 @@ describe('parseAtValue', () => {
               },
             },
             "name": "withoutColon",
-            "type": "valueDeclaration",
+            "type": "declaration",
           },
           "diagnostics": [],
         },
@@ -111,7 +111,7 @@ describe('parseAtValue', () => {
               },
             },
             "name": "empty",
-            "type": "valueDeclaration",
+            "type": "declaration",
           },
           "diagnostics": [],
         },
@@ -142,7 +142,7 @@ describe('parseAtValue', () => {
               },
             },
             "name": "comment",
-            "type": "valueDeclaration",
+            "type": "declaration",
           },
           "diagnostics": [],
         },
@@ -173,27 +173,13 @@ describe('parseAtValue', () => {
               },
             },
             "name": "complex",
-            "type": "valueDeclaration",
+            "type": "declaration",
           },
           "diagnostics": [],
         },
         {
           "atValue": {
-            "from": "test.css",
-            "fromLoc": {
-              "end": {
-                "column": 29,
-                "line": 6,
-                "offset": 155,
-              },
-              "start": {
-                "column": 21,
-                "line": 6,
-                "offset": 147,
-              },
-            },
-            "type": "valueImportDeclaration",
-            "values": [
+            "entries": [
               {
                 "loc": {
                   "end": {
@@ -210,26 +196,26 @@ describe('parseAtValue', () => {
                 "name": "import",
               },
             ],
+            "from": "test.css",
+            "fromLoc": {
+              "end": {
+                "column": 29,
+                "line": 6,
+                "offset": 155,
+              },
+              "start": {
+                "column": 21,
+                "line": 6,
+                "offset": 147,
+              },
+            },
+            "type": "importer",
           },
           "diagnostics": [],
         },
         {
           "atValue": {
-            "from": "test.css",
-            "fromLoc": {
-              "end": {
-                "column": 39,
-                "line": 7,
-                "offset": 196,
-              },
-              "start": {
-                "column": 31,
-                "line": 7,
-                "offset": 188,
-              },
-            },
-            "type": "valueImportDeclaration",
-            "values": [
+            "entries": [
               {
                 "loc": {
                   "end": {
@@ -261,26 +247,26 @@ describe('parseAtValue', () => {
                 "name": "import2",
               },
             ],
+            "from": "test.css",
+            "fromLoc": {
+              "end": {
+                "column": 39,
+                "line": 7,
+                "offset": 196,
+              },
+              "start": {
+                "column": 31,
+                "line": 7,
+                "offset": 188,
+              },
+            },
+            "type": "importer",
           },
           "diagnostics": [],
         },
         {
           "atValue": {
-            "from": "test.css",
-            "fromLoc": {
-              "end": {
-                "column": 40,
-                "line": 8,
-                "offset": 238,
-              },
-              "start": {
-                "column": 32,
-                "line": 8,
-                "offset": 230,
-              },
-            },
-            "type": "valueImportDeclaration",
-            "values": [
+            "entries": [
               {
                 "loc": {
                   "end": {
@@ -310,6 +296,20 @@ describe('parseAtValue', () => {
                 "name": "import3",
               },
             ],
+            "from": "test.css",
+            "fromLoc": {
+              "end": {
+                "column": 40,
+                "line": 8,
+                "offset": 238,
+              },
+              "start": {
+                "column": 32,
+                "line": 8,
+                "offset": 230,
+              },
+            },
+            "type": "importer",
           },
           "diagnostics": [],
         },
@@ -340,27 +340,13 @@ describe('parseAtValue', () => {
               },
             },
             "name": "withSpace1",
-            "type": "valueDeclaration",
+            "type": "declaration",
           },
           "diagnostics": [],
         },
         {
           "atValue": {
-            "from": "test.css",
-            "fromLoc": {
-              "end": {
-                "column": 63,
-                "line": 10,
-                "offset": 332,
-              },
-              "start": {
-                "column": 55,
-                "line": 10,
-                "offset": 324,
-              },
-            },
-            "type": "valueImportDeclaration",
-            "values": [
+            "entries": [
               {
                 "loc": {
                   "end": {
@@ -405,6 +391,20 @@ describe('parseAtValue', () => {
                 "name": "withSpace3",
               },
             ],
+            "from": "test.css",
+            "fromLoc": {
+              "end": {
+                "column": 63,
+                "line": 10,
+                "offset": 332,
+              },
+              "start": {
+                "column": 55,
+                "line": 10,
+                "offset": 324,
+              },
+            },
+            "type": "importer",
           },
           "diagnostics": [],
         },
@@ -446,21 +446,7 @@ describe('parseAtValue', () => {
         },
         {
           "atValue": {
-            "from": "test.css",
-            "fromLoc": {
-              "end": {
-                "column": 27,
-                "line": 2,
-                "offset": 34,
-              },
-              "start": {
-                "column": 19,
-                "line": 2,
-                "offset": 26,
-              },
-            },
-            "type": "valueImportDeclaration",
-            "values": [
+            "entries": [
               {
                 "loc": {
                   "end": {
@@ -492,6 +478,20 @@ describe('parseAtValue', () => {
                 "name": "b",
               },
             ],
+            "from": "test.css",
+            "fromLoc": {
+              "end": {
+                "column": 27,
+                "line": 2,
+                "offset": 34,
+              },
+              "start": {
+                "column": 19,
+                "line": 2,
+                "offset": 26,
+              },
+            },
+            "type": "importer",
           },
           "diagnostics": [
             {
@@ -532,7 +532,7 @@ describe('parseAtValue', () => {
               },
             },
             "name": "\\\\c",
-            "type": "valueDeclaration",
+            "type": "declaration",
           },
           "diagnostics": [],
         },
@@ -563,7 +563,7 @@ describe('parseAtValue', () => {
               },
             },
             "name": "\\'d",
-            "type": "valueDeclaration",
+            "type": "declaration",
           },
           "diagnostics": [],
         },
@@ -594,7 +594,7 @@ describe('parseAtValue', () => {
               },
             },
             "name": "\\31",
-            "type": "valueDeclaration",
+            "type": "declaration",
           },
           "diagnostics": [],
         },

--- a/packages/core/src/parser/at-value-parser.ts
+++ b/packages/core/src/parser/at-value-parser.ts
@@ -3,7 +3,7 @@ import postcssValueParser from 'postcss-value-parser';
 import type { DiagnosticWithDetachedLocation, Location } from '../type.js';
 
 interface ValueDeclaration {
-  type: 'valueDeclaration';
+  type: 'declaration';
   name: string;
   // value: string; // unused
   loc: Location;
@@ -14,9 +14,9 @@ interface ValueDeclaration {
   declarationLoc: Location;
 }
 
-interface ValueImportDeclaration {
-  type: 'valueImportDeclaration';
-  values: {
+interface ValueImporter {
+  type: 'importer';
+  entries: {
     name: string;
     loc: Location;
     localName?: string;
@@ -26,7 +26,7 @@ interface ValueImportDeclaration {
   fromLoc: Location;
 }
 
-type ParsedAtValue = ValueDeclaration | ValueImportDeclaration;
+type ParsedAtValue = ValueDeclaration | ValueImporter;
 
 interface ParseAtValueResult {
   atValue?: ParsedAtValue;
@@ -66,7 +66,7 @@ function parseValueImport(atValue: AtRule, nodes: postcssValueParser.Node[]): Pa
   const fromIndex = findFromKeywordIndex(nodes);
   const specifierNode = nodes.slice(fromIndex + 1).find((node) => node.type === 'string')!;
 
-  const values: ValueImportDeclaration['values'] = [];
+  const entries: ValueImporter['entries'] = [];
   const diagnostics: DiagnosticWithDetachedLocation[] = [];
   for (const item of splitByComma(nodes.slice(0, fromIndex))) {
     const words = item.nodes.filter((node) => node.type === 'word');
@@ -82,21 +82,21 @@ function parseValueImport(atValue: AtRule, nodes: postcssValueParser.Node[]): Pa
       });
       continue;
     }
-    const value: ValueImportDeclaration['values'][number] = {
+    const entry: ValueImporter['entries'][number] = {
       name: nameNode.value,
       loc: calcAtValueParamsLoc(atValue, nameNode.sourceIndex, nameNode.value.length),
     };
     const localNode = words[1]?.value === 'as' ? words[2] : undefined;
     if (localNode !== undefined) {
-      value.localName = localNode.value;
-      value.localLoc = calcAtValueParamsLoc(atValue, localNode.sourceIndex, localNode.value.length);
+      entry.localName = localNode.value;
+      entry.localLoc = calcAtValueParamsLoc(atValue, localNode.sourceIndex, localNode.value.length);
     }
-    values.push(value);
+    entries.push(entry);
   }
 
-  const parsedAtValue: ValueImportDeclaration = {
-    type: 'valueImportDeclaration',
-    values,
+  const parsedAtValue: ValueImporter = {
+    type: 'importer',
+    entries,
     from: specifierNode.value,
     // The location of the specifier without quotes.
     fromLoc: calcAtValueParamsLoc(atValue, specifierNode.sourceIndex + 1, specifierNode.value.length),
@@ -122,7 +122,7 @@ function parseValueDeclaration(atValue: AtRule, nodes: postcssValueParser.Node[]
     };
   }
   const parsedAtValue: ValueDeclaration = {
-    type: 'valueDeclaration',
+    type: 'declaration',
     name: nameNode.value,
     loc: calcAtValueParamsLoc(atValue, nameNode.sourceIndex, nameNode.value.length),
     declarationLoc: {

--- a/packages/core/src/parser/at-value-parser.ts
+++ b/packages/core/src/parser/at-value-parser.ts
@@ -5,7 +5,6 @@ import type { DiagnosticWithDetachedLocation, Location } from '../type.js';
 interface ValueDeclaration {
   type: 'declaration';
   name: string;
-  // value: string; // unused
   loc: Location;
   /**
    * NOTE: The `declarationLoc` for value declaration does not include the trailing semicolon.
@@ -41,17 +40,17 @@ interface ParseAtValueResult {
  */
 export function parseAtValue(atValue: AtRule): ParseAtValueResult {
   const nodes = postcssValueParser(atValue.params).nodes;
-  if (isValueImport(nodes)) {
-    return parseValueImport(atValue, nodes);
+  if (isValueImporter(nodes)) {
+    return parseValueImporter(atValue, nodes);
   }
   return parseValueDeclaration(atValue, nodes);
 }
 
 /**
- * Check that the params form a value import: one or more nodes followed by `from`
+ * Check that the params form a value importer: one or more nodes followed by `from`
  * and a single quoted specifier (e.g. `'./test.module.css'`).
  */
-function isValueImport(nodes: postcssValueParser.Node[]): boolean {
+function isValueImporter(nodes: postcssValueParser.Node[]): boolean {
   const fromIndex = findFromKeywordIndex(nodes);
   if (fromIndex < 1) return false;
   const tail = nodes.slice(fromIndex + 1).filter((node) => node.type !== 'space');
@@ -62,7 +61,7 @@ function findFromKeywordIndex(nodes: postcssValueParser.Node[]): number {
   return nodes.findLastIndex((node) => node.type === 'word' && node.value === 'from');
 }
 
-function parseValueImport(atValue: AtRule, nodes: postcssValueParser.Node[]): ParseAtValueResult {
+function parseValueImporter(atValue: AtRule, nodes: postcssValueParser.Node[]): ParseAtValueResult {
   const fromIndex = findFromKeywordIndex(nodes);
   const specifierNode = nodes.slice(fromIndex + 1).find((node) => node.type === 'string')!;
 

--- a/packages/core/src/parser/css-module-parser.ts
+++ b/packages/core/src/parser/css-module-parser.ts
@@ -62,11 +62,11 @@ function collectTokens(ast: Root, keyframes: boolean) {
       const { atValue, diagnostics } = parseAtValue(node);
       allDiagnostics.push(...diagnostics);
       if (atValue === undefined) return;
-      if (atValue.type === 'valueDeclaration') {
+      if (atValue.type === 'declaration') {
         localTokens.push({ name: atValue.name, loc: atValue.loc, declarationLoc: atValue.declarationLoc });
-      } else if (atValue.type === 'valueImportDeclaration') {
-        const { values, ...rest } = atValue;
-        tokenImporters.push({ ...rest, type: 'named', entries: values });
+      } else if (atValue.type === 'importer') {
+        const { type: _, ...rest } = atValue;
+        tokenImporters.push({ ...rest, type: 'named' });
       }
     } else if (keyframes && isAtKeyframesNode(node)) {
       const { keyframe, diagnostics } = parseAtKeyframes(node);


### PR DESCRIPTION
## What

Internal-only refactor of the CSS Module parsers. No user-facing behavior change.

- Rename the `@value` parser node types for consistency with the surrounding vocabulary (`TokenImporter`, `entries`):
  - `ValueImportDeclaration` → `ValueImporter`
  - `values` → `entries` (matches `NamedTokenImporter` / `ExternalTokenReference`), which also lets the consumer drop a rename step
  - discriminant `'valueDeclaration'` / `'valueImportDeclaration'` → `'declaration'` / `'importer'`
  - `isValueImport` / `parseValueImport` → `isValueImporter` / `parseValueImporter`
- Drop a dead commented-out field in `ValueDeclaration`
- Compute the `@import` specifier location with `positionBy` instead of hand-rolling line/column/offset

These types are not exported, so there is no public API change.

## How to verify

```bash
vp check
vp test --project unit packages/core
```

Existing parser tests (including inline snapshots) pass, confirming the `positionBy`-based `@import` location matches the previous hand-rolled computation.