### PR TITLE
feat(codegen): add --cache option to skip emitting unchanged files

### DIFF
--- a/.changeset/codegen-cache.md
+++ b/.changeset/codegen-cache.md
@@ -1,0 +1,5 @@
+---
+'@css-modules-kit/codegen': minor
+---
+
+feat(codegen): add `--cache` option to skip emitting unchanged files

--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -28,6 +28,7 @@ Options:
   --clean                Remove the output directory before generating files.                       [default: false]
   --watch, -w            Watch for changes and regenerate files.                                    [default: false]
   --preserveWatchOutput  Disable wiping the console in watch mode.                                  [default: false]
+  --cache                Only emit files that have changed since the last run.                      [default: false]
 ```
 
 ## Configuration

--- a/packages/codegen/src/cache.ts
+++ b/packages/codegen/src/cache.ts
@@ -1,0 +1,73 @@
+import { createHash } from 'node:crypto';
+import { readFile, mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join, relative } from '@css-modules-kit/core';
+import type { CMKConfig } from '@css-modules-kit/core';
+import packageJson from '../package.json' with { type: 'json' };
+
+interface CacheData {
+  version: string;
+  configHash: string;
+  files: Record<string, string>;
+}
+
+function computeConfigHash(config: CMKConfig): string {
+  return createHash('sha256').update(JSON.stringify(config)).digest('hex');
+}
+
+function computeContentHash(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+export class Cache {
+  readonly filePath: string;
+  private readonly configHash: string;
+  private readonly basePath: string;
+  // Use a null-prototype object so that keys like `__proto__` are stored as own properties
+  // without interfering with the prototype chain.
+  private files: Record<string, string> = Object.create(null);
+
+  constructor(config: CMKConfig) {
+    this.filePath = join(config.dtsOutDir, '.cache');
+    this.configHash = computeConfigHash(config);
+    this.basePath = config.basePath;
+  }
+
+  async load(): Promise<void> {
+    let text: string;
+    try {
+      text = await readFile(this.filePath, 'utf-8');
+    } catch {
+      return;
+    }
+    let data: CacheData;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      return;
+    }
+    if (data.version !== packageJson.version || data.configHash !== this.configHash) {
+      return;
+    }
+    this.files = Object.assign(Object.create(null), data.files);
+  }
+
+  isHit(fileName: string, text: string): boolean {
+    const relPath = relative(this.basePath, fileName);
+    return this.files[relPath] === computeContentHash(text);
+  }
+
+  record(fileName: string, text: string): void {
+    const relPath = relative(this.basePath, fileName);
+    this.files[relPath] = computeContentHash(text);
+  }
+
+  async save(): Promise<void> {
+    const data: CacheData = {
+      version: packageJson.version,
+      configHash: this.configHash,
+      files: this.files,
+    };
+    await mkdir(dirname(this.filePath), { recursive: true });
+    await writeFile(this.filePath, JSON.stringify(data));
+  }
+}

--- a/packages/codegen/src/cli.test.ts
+++ b/packages/codegen/src/cli.test.ts
@@ -16,6 +16,7 @@ describe('parseCLIArgs', () => {
       clean: false,
       watch: false,
       preserveWatchOutput: false,
+      cache: false,
     });
   });
   it('should parse --help option', () => {
@@ -51,6 +52,10 @@ describe('parseCLIArgs', () => {
   it('should parse --preserveWatchOutput option', () => {
     expect(parseCLIArgs(['--preserveWatchOutput'], cwd).preserveWatchOutput).toBe(true);
     expect(parseCLIArgs(['--no-preserveWatchOutput'], cwd).preserveWatchOutput).toBe(false);
+  });
+  it('should parse --cache option', () => {
+    expect(parseCLIArgs(['--cache'], cwd).cache).toBe(true);
+    expect(parseCLIArgs(['--no-cache'], cwd).cache).toBe(false);
   });
   it('should throw ParseCLIArgsError for invalid options', () => {
     expect(() => parseCLIArgs(['--invalid-option'], cwd)).toThrow(ParseCLIArgsError);

--- a/packages/codegen/src/cli.ts
+++ b/packages/codegen/src/cli.ts
@@ -15,6 +15,7 @@ Options:
   --clean                Remove the output directory before generating files.                       [default: false]
   --watch, -w            Watch for changes and regenerate files.                                    [default: false]
   --preserveWatchOutput  Disable wiping the console in watch mode.                                  [default: false]
+  --cache                Only emit files that have changed since the last run.                      [default: false]
 `;
 
 export function printHelpText(): void {
@@ -33,6 +34,7 @@ export interface ParsedArgs {
   clean: boolean;
   watch: boolean;
   preserveWatchOutput: boolean;
+  cache: boolean;
 }
 
 /**
@@ -51,6 +53,7 @@ export function parseCLIArgs(args: string[], cwd: string): ParsedArgs {
         clean: { type: 'boolean', default: false },
         watch: { type: 'boolean', short: 'w', default: false },
         preserveWatchOutput: { type: 'boolean', default: false },
+        cache: { type: 'boolean', default: false },
       },
       allowNegative: true,
     });
@@ -62,6 +65,7 @@ export function parseCLIArgs(args: string[], cwd: string): ParsedArgs {
       clean: values.clean,
       watch: values.watch,
       preserveWatchOutput: values.preserveWatchOutput,
+      cache: values.cache,
     };
   } catch (cause) {
     throw new ParseCLIArgsError(cause);

--- a/packages/codegen/src/project.ts
+++ b/packages/codegen/src/project.ts
@@ -12,6 +12,7 @@ import {
   readConfigFile,
 } from '@css-modules-kit/core';
 import ts from 'typescript';
+import type { Cache } from './cache.js';
 import { writeDtsFile } from './dts-writer.js';
 import { ReadCSSModuleFileError } from './error.js';
 
@@ -48,7 +49,7 @@ export interface Project {
    * Emit .d.ts files for all project files.
    * @throws {WriteDtsFileError}
    */
-  emitDtsFiles(): Promise<void>;
+  emitDtsFiles(cache?: Cache): Promise<void>;
 }
 
 /**
@@ -201,10 +202,11 @@ export function createProject(args: ProjectArgs): Project {
   /**
    * @throws {WriteDtsFileError}
    */
-  async function emitDtsFiles(): Promise<void> {
+  async function emitDtsFiles(cache?: Cache): Promise<void> {
     const promises: Promise<void>[] = [];
     for (const cssModule of cssModuleMap.values()) {
       if (emittedSet.has(cssModule.fileName)) continue;
+      if (cache?.isHit(cssModule.fileName, cssModule.text)) continue;
       const dts = generateDts(cssModule, { ...config, forTsPlugin: false });
       promises.push(
         writeDtsFile(dts.text, cssModule.fileName, {
@@ -213,6 +215,7 @@ export function createProject(args: ProjectArgs): Project {
           arbitraryExtensions: config.arbitraryExtensions,
         }).then(() => {
           emittedSet.add(cssModule.fileName);
+          cache?.record(cssModule.fileName, cssModule.text);
         }),
       );
     }

--- a/packages/codegen/src/runner.test.ts
+++ b/packages/codegen/src/runner.test.ts
@@ -1,4 +1,4 @@
-import { access, rm, writeFile } from 'node:fs/promises';
+import { access, readFile, rm, writeFile } from 'node:fs/promises';
 import { platform } from 'node:process';
 import dedent from 'dedent';
 import { afterEach, describe, expect, test, vi } from 'vite-plus/test';
@@ -107,6 +107,99 @@ describe('runCMK', () => {
       'src/a.module.css': '.a_1 { color: red; }',
     });
     await expect(runCMK(fakeParsedArgs({ project: iff.rootDir }), createLoggerSpy())).rejects.toThrow(CMKDisabledError);
+  });
+  describe('--cache', () => {
+    test('writes a cache file under dtsOutDir', async () => {
+      const iff = await createIFF({
+        'tsconfig.json': '{ "cmkOptions": { "enabled": true, "dtsOutDir": "generated" } }',
+        'src/a.module.css': '.a_1 { color: red; }',
+      });
+      await runCMK(fakeParsedArgs({ project: iff.rootDir, cache: true }), createLoggerSpy());
+      const cacheText = await readFile(iff.join('generated/.cache'), 'utf-8');
+      const cache = JSON.parse(cacheText);
+      expect(cache).toMatchObject({
+        version: expect.any(String),
+        configHash: expect.any(String),
+        files: { 'src/a.module.css': expect.any(String) },
+      });
+    });
+    test('skips emitting an unchanged file on the second run', async () => {
+      const iff = await createIFF({
+        'tsconfig.json': '{ "cmkOptions": { "enabled": true, "dtsOutDir": "generated" } }',
+        'src/a.module.css': '.a_1 { color: red; }',
+      });
+      await runCMK(fakeParsedArgs({ project: iff.rootDir, cache: true }), createLoggerSpy());
+      await writeFile(iff.join('generated/src/a.module.css.d.ts'), 'STALE');
+      await runCMK(fakeParsedArgs({ project: iff.rootDir, cache: true }), createLoggerSpy());
+      expect(await readFile(iff.join('generated/src/a.module.css.d.ts'), 'utf-8')).toBe('STALE');
+    });
+    test('reemits only the file whose content changed', async () => {
+      const iff = await createIFF({
+        'tsconfig.json': '{ "cmkOptions": { "enabled": true, "dtsOutDir": "generated" } }',
+        'src/a.module.css': '.a_1 { color: red; }',
+        'src/b.module.css': '.b_1 { color: blue; }',
+      });
+      await runCMK(fakeParsedArgs({ project: iff.rootDir, cache: true }), createLoggerSpy());
+      await writeFile(iff.join('generated/src/a.module.css.d.ts'), 'STALE');
+      await writeFile(iff.join('generated/src/b.module.css.d.ts'), 'STALE');
+      await writeFile(iff.join('src/a.module.css'), '.a_2 { color: green; }');
+      await runCMK(fakeParsedArgs({ project: iff.rootDir, cache: true }), createLoggerSpy());
+      expect(await readFile(iff.join('generated/src/a.module.css.d.ts'), 'utf-8')).not.toBe('STALE');
+      expect(await readFile(iff.join('generated/src/b.module.css.d.ts'), 'utf-8')).toBe('STALE');
+    });
+    test('invalidates the entire cache when cmkOptions change', async () => {
+      const iff = await createIFF({
+        'tsconfig.json': '{ "cmkOptions": { "enabled": true, "dtsOutDir": "generated" } }',
+        'src/a.module.css': '.a_1 { color: red; }',
+      });
+      await runCMK(fakeParsedArgs({ project: iff.rootDir, cache: true }), createLoggerSpy());
+      await writeFile(iff.join('generated/src/a.module.css.d.ts'), 'STALE');
+      await writeFile(
+        iff.join('tsconfig.json'),
+        '{ "cmkOptions": { "enabled": true, "dtsOutDir": "generated", "namedExports": true } }',
+      );
+      await runCMK(fakeParsedArgs({ project: iff.rootDir, cache: true }), createLoggerSpy());
+      expect(await readFile(iff.join('generated/src/a.module.css.d.ts'), 'utf-8')).not.toBe('STALE');
+    });
+    test('invalidates the entire cache when the cache version changes', async () => {
+      const iff = await createIFF({
+        'tsconfig.json': '{ "cmkOptions": { "enabled": true, "dtsOutDir": "generated" } }',
+        'src/a.module.css': '.a_1 { color: red; }',
+      });
+      await runCMK(fakeParsedArgs({ project: iff.rootDir, cache: true }), createLoggerSpy());
+      await writeFile(iff.join('generated/src/a.module.css.d.ts'), 'STALE');
+      const cacheText = await readFile(iff.join('generated/.cache'), 'utf-8');
+      const cache = JSON.parse(cacheText);
+      await writeFile(iff.join('generated/.cache'), JSON.stringify({ ...cache, version: '0.0.0-old' }));
+      await runCMK(fakeParsedArgs({ project: iff.rootDir, cache: true }), createLoggerSpy());
+      expect(await readFile(iff.join('generated/src/a.module.css.d.ts'), 'utf-8')).not.toBe('STALE');
+    });
+    test('emits all files when clean is used together', async () => {
+      const iff = await createIFF({
+        'tsconfig.json': '{ "cmkOptions": { "enabled": true, "dtsOutDir": "generated" } }',
+        'src/a.module.css': '.a_1 { color: red; }',
+      });
+      await runCMK(fakeParsedArgs({ project: iff.rootDir, cache: true }), createLoggerSpy());
+      await writeFile(iff.join('generated/src/a.module.css.d.ts'), 'STALE');
+      await runCMK(fakeParsedArgs({ project: iff.rootDir, cache: true, clean: true }), createLoggerSpy());
+      expect(await readFile(iff.join('generated/src/a.module.css.d.ts'), 'utf-8')).not.toBe('STALE');
+    });
+    test('reports a diagnostic for an unchanged file when its dependency changes', async () => {
+      const iff = await createIFF({
+        'tsconfig.json': '{ "cmkOptions": { "enabled": true, "dtsOutDir": "generated" } }',
+        'src/a.module.css': `@value b_1 from './b.module.css';\n.a_1 { color: red; }`,
+        'src/b.module.css': '.b_1 { color: blue; }',
+      });
+      const loggerSpy1 = createLoggerSpy();
+      await runCMK(fakeParsedArgs({ project: iff.rootDir, cache: true }), loggerSpy1);
+      expect(loggerSpy1.logDiagnostics).not.toHaveBeenCalled();
+      await writeFile(iff.join('generated/src/a.module.css.d.ts'), 'STALE');
+      await writeFile(iff.join('src/b.module.css'), '.b_2 { color: blue; }');
+      const loggerSpy2 = createLoggerSpy();
+      await runCMK(fakeParsedArgs({ project: iff.rootDir, cache: true }), loggerSpy2);
+      expect(loggerSpy2.logDiagnostics).toHaveBeenCalledTimes(1);
+      expect(await readFile(iff.join('generated/src/a.module.css.d.ts'), 'utf-8')).toBe('STALE');
+    });
   });
 });
 

--- a/packages/codegen/src/runner.ts
+++ b/packages/codegen/src/runner.ts
@@ -2,6 +2,7 @@ import type { Stats } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { basename } from '@css-modules-kit/core';
 import chokidar, { type FSWatcher } from 'chokidar';
+import { Cache } from './cache.js';
 import { CMKDisabledError } from './error.js';
 import type { Logger } from './logger/logger.js';
 import { createProject, type Project } from './project.js';
@@ -16,6 +17,7 @@ interface RunnerArgs {
   project: string;
   clean: boolean;
   preserveWatchOutput: boolean;
+  cache: boolean;
 }
 
 export interface Watcher {
@@ -40,7 +42,13 @@ export async function runCMK(args: RunnerArgs, logger: Logger): Promise<boolean>
   if (args.clean) {
     await rm(project.config.dtsOutDir, { recursive: true, force: true });
   }
-  await project.emitDtsFiles();
+  let cache: Cache | undefined;
+  if (args.cache) {
+    cache = new Cache(project.config);
+    await cache.load();
+  }
+  await project.emitDtsFiles(cache);
+  await cache?.save();
   const diagnostics = project.getDiagnostics();
   if (diagnostics.length > 0) {
     logger.logDiagnostics(diagnostics);

--- a/packages/codegen/src/test/faker.ts
+++ b/packages/codegen/src/test/faker.ts
@@ -9,6 +9,7 @@ export function fakeParsedArgs(args?: Partial<ParsedArgs>): ParsedArgs {
     clean: false,
     watch: false,
     preserveWatchOutput: false,
+    cache: false,
     ...args,
   };
 }


### PR DESCRIPTION
ref: #413 

## Summary

- Adds `--cache` flag to `cmk`. When enabled, files whose content has not changed since the last run skip the emit phase (`generateDts` + `writeDtsFile`).
- The cache is stored at `<dtsOutDir>/.cache`. Running `--clean` automatically discards it since the entire output directory is removed.
- Parse and check phases still run on every invocation, so diagnostics remain accurate even when a dependency changes without the file itself changing.

## How it works

On each run with `--cache`:

1. Load `<dtsOutDir>/.cache` (JSON). If the codegen version or the config hash differs from what is stored, discard the cache entirely.
2. For each CSS module file, compute a SHA-256 hash of its content. If it matches the stored hash, skip emit for that file.
3. After emitting, write the updated cache back to disk.

The cache file format:

```json
{
  "version": "<codegen version>",
  "configHash": "<SHA-256 of JSON.stringify(CMKConfig)>",
  "files": {
    "src/a.module.css": "<SHA-256 of file content>",
    ...
  }
}
```

## Performance

Measured with [hyperfine](https://github.com/sharkdp/hyperfine) on a synthetic project (30 selectors and 1 `@import` per file). Times include Node.js startup (~200 ms).

| Files | no-cache | cache-cold | cache-warm |
|------:|---------:|-----------:|-----------:|
|   100 | 172 ± 1 ms | 175 ± 1 ms (+2%) | 154 ± 1 ms (−10%) |
|   500 | 249 ± 5 ms | 265 ± 3 ms (+6%) | 195 ± 2 ms (−22%) |
|  1000 | 333 ± 6 ms | 351 ± 3 ms (+6%) | 242 ± 4 ms (−27%) |
| 10000 | 1772 ± 18 ms | 2052 ± 24 ms (+16%) | 975 ± 3 ms (−45%) |

- **cache-cold** (first run with `--cache`, no existing cache) adds a small overhead for hashing every file and writing the cache, growing with file count (+2% at 100 files, +16% at 10000).
- **cache-warm** (subsequent run, source files unchanged) is **10–45% faster**. The speedup grows with the number of files and is bounded by the parse + check phases, which always run.

<details>
<summary>Benchmark code</summary>

**setup.mjs** — generates a synthetic project with N files

```js
import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
import { tmpdir } from 'node:os';
import { join } from 'node:path';

const N = parseInt(process.argv[2], 10);
if (!N || N <= 0) {
  console.error('Usage: node setup.mjs <N>');
  process.exit(1);
}

const SELECTORS = 30;

const dir = join(tmpdir(), 'cmk-bench-v2', `proj-${N}`);
rmSync(dir, { recursive: true, force: true });
mkdirSync(join(dir, 'src'), { recursive: true });

writeFileSync(
  join(dir, 'tsconfig.json'),
  JSON.stringify({ cmkOptions: { enabled: true, dtsOutDir: 'generated' } }),
);

for (let i = 0; i < N; i++) {
  let css = '';
  if (i !== 1) {
    css += `@import './file1.module.css';\n`;
  }
  for (let s = 0; s < SELECTORS; s++) {
    css += `.file${i}_${s + 1} { color: red; }\n`;
  }
  writeFileSync(join(dir, 'src', `file${i}.module.css`), css);
}

console.log(dir);
```

**bench.sh** — runs hyperfine for each scenario

```bash
#!/usr/bin/env bash
set -euo pipefail

CMK="node /path/to/css-modules-kit/packages/codegen/bin/cmk.js"

for N in 100 500 1000 10000; do
  PROJ=$(node setup.mjs "$N")

  # no-cache vs cache-cold: delete generated before each run
  hyperfine \
    --warmup 3 \
    --prepare "rm -rf $PROJ/generated" \
    --command-name "no-cache"    "$CMK --project $PROJ" \
    --command-name "cache-cold"  "$CMK --project $PROJ --cache"

  # cache-warm: cache + .d.ts files already exist, nothing changed
  hyperfine \
    --warmup 3 \
    --command-name "cache-warm" \
    "$CMK --project $PROJ --cache"

  rm -rf "$PROJ"
done
```

</details>

## Test plan

- Run `vp test packages/codegen` and confirm all tests pass.
