### PR TITLE
refactor(core): unify parser predicate naming and tidy collectTokens

### DIFF
--- a/packages/core/src/parser/at-import-parser.test.ts
+++ b/packages/core/src/parser/at-import-parser.test.ts
@@ -1,9 +1,9 @@
 import dedent from 'dedent';
 import { expect, test } from 'vite-plus/test';
 import { fakeAtImports, fakeRoot } from '../test/ast.js';
-import { parseAtImport } from './at-import-parser.js';
+import { parseImportAtRule } from './at-import-parser.js';
 
-test('parseAtImport', () => {
+test('parseImportAtRule', () => {
   const atImports = fakeAtImports(
     fakeRoot(dedent`
       @import;
@@ -13,7 +13,7 @@ test('parseAtImport', () => {
       @import "test.css" print;
     `),
   );
-  expect(atImports.map(parseAtImport)).toMatchInlineSnapshot(`
+  expect(atImports.map(parseImportAtRule)).toMatchInlineSnapshot(`
     [
       undefined,
       {

--- a/packages/core/src/parser/at-import-parser.ts
+++ b/packages/core/src/parser/at-import-parser.ts
@@ -12,7 +12,7 @@ interface ParsedAtImport {
  * @param atImport The `@import` rule to parse.
  * @returns The specifier of the imported file.
  */
-export function parseAtImport(atImport: AtRule): ParsedAtImport | undefined {
+export function parseImportAtRule(atImport: AtRule): ParsedAtImport | undefined {
   const firstNode = postcssValueParser(atImport.params).nodes[0];
   if (firstNode === undefined) return undefined;
   if (firstNode.type === 'string') return convertParsedAtImport(atImport, firstNode);

--- a/packages/core/src/parser/at-value-parser.test.ts
+++ b/packages/core/src/parser/at-value-parser.test.ts
@@ -1,9 +1,9 @@
 import dedent from 'dedent';
 import { describe, expect, test } from 'vite-plus/test';
 import { fakeAtValues, fakeRoot } from '../test/ast.js';
-import { parseAtValue } from './at-value-parser.js';
+import { parseValueAtRule } from './at-value-parser.js';
 
-describe('parseAtValue', () => {
+describe('parseValueAtRule', () => {
   test('parses syntax supported by css-loader', () => {
     const atValues = fakeAtValues(
       fakeRoot(dedent`
@@ -19,7 +19,7 @@ describe('parseAtValue', () => {
          @value  withSpace2 ,  withSpace3  as  alias2  from  "test.css" ;
       `),
     );
-    const result = atValues.map(parseAtValue);
+    const result = atValues.map(parseValueAtRule);
     expect(result).toMatchInlineSnapshot(`
       [
         {
@@ -428,7 +428,7 @@ describe('parseAtValue', () => {
         @value \31 e: #000;
       `),
     );
-    const result = atValues.map(parseAtValue);
+    const result = atValues.map(parseValueAtRule);
     expect(result).toMatchInlineSnapshot(`
       [
         {

--- a/packages/core/src/parser/at-value-parser.ts
+++ b/packages/core/src/parser/at-value-parser.ts
@@ -38,7 +38,7 @@ interface ParseAtValueResult {
  * MEMO: css-modules-kit does not support `@value` with parentheses (e.g., `@value (a, b) from '...';`) to simplify the implementation.
  * MEMO: css-modules-kit does not support `@value` with variable module name (e.g., `@value a from moduleName;`) to simplify the implementation.
  */
-export function parseAtValue(atValue: AtRule): ParseAtValueResult {
+export function parseValueAtRule(atValue: AtRule): ParseAtValueResult {
   const nodes = postcssValueParser(atValue.params).nodes;
   if (isValueImporter(nodes)) {
     return parseValueImporter(atValue, nodes);

--- a/packages/core/src/parser/css-module-parser.ts
+++ b/packages/core/src/parser/css-module-parser.ts
@@ -63,34 +63,36 @@ function collectTokens(ast: Root, keyframes: boolean, dashedIdents: boolean) {
   const tokenImporters: TokenImporter[] = [];
   const tokenReferences: TokenReference[] = [];
   ast.walk((node) => {
-    if (dashedIdents && isAtRule(node) && isDashedIdentAtRuleName(node.name)) {
-      const { token, diagnostics } = parseDashedIdentAtRule(node);
-      allDiagnostics.push(...diagnostics);
-      if (token) localTokens.push(token);
-    } else if (dashedIdents && isAtRule(node) && isMediaAtRuleName(node.name)) {
-      tokenReferences.push(...parseDashedIdentMediaQuery(node));
-    } else if (dashedIdents && isAtRule(node) && isContainerAtRuleName(node.name)) {
-      tokenReferences.push(...parseDashedIdentContainerQuery(node));
-    } else if (isAtRule(node) && isImportAtRuleName(node.name)) {
-      const parsed = parseImportAtRule(node);
-      if (parsed !== undefined) {
-        tokenImporters.push({ type: 'all', ...parsed });
-      }
-    } else if (isAtRule(node) && isValueAtRuleName(node.name)) {
-      const { atValue, diagnostics } = parseValueAtRule(node);
-      allDiagnostics.push(...diagnostics);
-      if (atValue === undefined) return;
-      if (atValue.type === 'declaration') {
-        localTokens.push({ name: atValue.name, loc: atValue.loc, declarationLoc: atValue.declarationLoc });
-      } else if (atValue.type === 'importer') {
-        const { type: _, ...rest } = atValue;
-        tokenImporters.push({ ...rest, type: 'named' });
-      }
-    } else if (keyframes && isAtRule(node) && isKeyframesAtRuleName(node.name)) {
-      const { keyframe, diagnostics } = parseKeyframesAtRule(node);
-      allDiagnostics.push(...diagnostics);
-      if (keyframe) {
-        localTokens.push({ name: keyframe.name, loc: keyframe.loc, declarationLoc: keyframe.declarationLoc });
+    if (isAtRule(node)) {
+      if (dashedIdents && isDashedIdentAtRuleName(node.name)) {
+        const { token, diagnostics } = parseDashedIdentAtRule(node);
+        allDiagnostics.push(...diagnostics);
+        if (token) localTokens.push(token);
+      } else if (dashedIdents && isMediaAtRuleName(node.name)) {
+        tokenReferences.push(...parseDashedIdentMediaQuery(node));
+      } else if (dashedIdents && isContainerAtRuleName(node.name)) {
+        tokenReferences.push(...parseDashedIdentContainerQuery(node));
+      } else if (isImportAtRuleName(node.name)) {
+        const parsed = parseImportAtRule(node);
+        if (parsed !== undefined) {
+          tokenImporters.push({ type: 'all', ...parsed });
+        }
+      } else if (isValueAtRuleName(node.name)) {
+        const { atValue, diagnostics } = parseValueAtRule(node);
+        allDiagnostics.push(...diagnostics);
+        if (atValue === undefined) return;
+        if (atValue.type === 'declaration') {
+          localTokens.push({ name: atValue.name, loc: atValue.loc, declarationLoc: atValue.declarationLoc });
+        } else if (atValue.type === 'importer') {
+          const { type: _, ...rest } = atValue;
+          tokenImporters.push({ ...rest, type: 'named' });
+        }
+      } else if (keyframes && isKeyframesAtRuleName(node.name)) {
+        const { keyframe, diagnostics } = parseKeyframesAtRule(node);
+        allDiagnostics.push(...diagnostics);
+        if (keyframe) {
+          localTokens.push({ name: keyframe.name, loc: keyframe.loc, declarationLoc: keyframe.declarationLoc });
+        }
       }
     } else if (isRule(node)) {
       const { classSelectors, diagnostics } = parseRule(node);
@@ -98,20 +100,22 @@ function collectTokens(ast: Root, keyframes: boolean, dashedIdents: boolean) {
       for (const classSelector of classSelectors) {
         localTokens.push(classSelector);
       }
-    } else if (keyframes && isDeclaration(node) && isAnimationNameProp(node.prop)) {
-      const { references, diagnostics } = parseAnimationNameProp(node);
-      allDiagnostics.push(...diagnostics);
-      tokenReferences.push(...references);
-    } else if (keyframes && isDeclaration(node) && isAnimationProp(node.prop)) {
-      const { references, diagnostics } = parseAnimationProp(node);
-      allDiagnostics.push(...diagnostics);
-      tokenReferences.push(...references);
-    } else if (isDeclaration(node) && isComposesProp(node.prop)) {
-      tokenReferences.push(...parseComposesProp(node));
-    } else if (dashedIdents && isDeclaration(node)) {
-      const { localTokens: tokens, references } = parseDashedIdentDecl(node);
-      localTokens.push(...tokens);
-      tokenReferences.push(...references);
+    } else if (isDeclaration(node)) {
+      if (keyframes && isAnimationNameProp(node.prop)) {
+        const { references, diagnostics } = parseAnimationNameProp(node);
+        allDiagnostics.push(...diagnostics);
+        tokenReferences.push(...references);
+      } else if (keyframes && isAnimationProp(node.prop)) {
+        const { references, diagnostics } = parseAnimationProp(node);
+        allDiagnostics.push(...diagnostics);
+        tokenReferences.push(...references);
+      } else if (isComposesProp(node.prop)) {
+        tokenReferences.push(...parseComposesProp(node));
+      } else if (dashedIdents) {
+        const { localTokens: tokens, references } = parseDashedIdentDecl(node);
+        localTokens.push(...tokens);
+        tokenReferences.push(...references);
+      }
     }
   });
   return { localTokens, tokenImporters, tokenReferences, diagnostics: allDiagnostics };

--- a/packages/core/src/parser/css-module-parser.ts
+++ b/packages/core/src/parser/css-module-parser.ts
@@ -15,46 +15,42 @@ import {
   parseAnimationNameProp,
   parseAnimationProp,
 } from './animation-parser.js';
-import { parseAtImport } from './at-import-parser.js';
-import { parseAtValue } from './at-value-parser.js';
+import { parseImportAtRule } from './at-import-parser.js';
+import { parseValueAtRule } from './at-value-parser.js';
 import { isComposesProp, parseComposesProp } from './composes-parser.js';
 import {
-  isContainerAtRule,
-  isDashedIdentAtRule,
-  isMediaAtRule,
+  isContainerAtRuleName,
+  isDashedIdentAtRuleName,
+  isMediaAtRuleName,
   parseDashedIdentAtRule,
   parseDashedIdentContainerQuery,
   parseDashedIdentDecl,
   parseDashedIdentMediaQuery,
 } from './dashed-ident-parser.js';
-import { parseAtKeyframes } from './key-frame-parser.js';
+import { parseKeyframesAtRule } from './key-frame-parser.js';
 import { parseRule } from './rule-parser.js';
 
-type AtImport = AtRule & { name: 'import' };
-type AtValue = AtRule & { name: 'value' };
-type AtKeyframes = AtRule & { name: 'keyframes' };
-
-function isAtRuleNode(node: Node): node is AtRule {
+function isAtRule(node: Node): node is AtRule {
   return node.type === 'atrule';
 }
 
-function isAtImportNode(node: Node): node is AtImport {
-  return isAtRuleNode(node) && node.name === 'import';
+function isImportAtRuleName(name: string): boolean {
+  return name === 'import';
 }
 
-function isAtValueNode(node: Node): node is AtValue {
-  return isAtRuleNode(node) && node.name === 'value';
+function isValueAtRuleName(name: string): boolean {
+  return name === 'value';
 }
 
-function isAtKeyframesNode(node: Node): node is AtKeyframes {
-  return isAtRuleNode(node) && node.name === 'keyframes';
+function isKeyframesAtRuleName(name: string): boolean {
+  return name === 'keyframes';
 }
 
-function isRuleNode(node: Node): node is Rule {
+function isRule(node: Node): node is Rule {
   return node.type === 'rule';
 }
 
-function isDeclarationNode(node: Node): node is Declaration {
+function isDeclaration(node: Node): node is Declaration {
   return node.type === 'decl';
 }
 
@@ -67,21 +63,21 @@ function collectTokens(ast: Root, keyframes: boolean, dashedIdents: boolean) {
   const tokenImporters: TokenImporter[] = [];
   const tokenReferences: TokenReference[] = [];
   ast.walk((node) => {
-    if (dashedIdents && isAtRuleNode(node) && isDashedIdentAtRule(node.name)) {
+    if (dashedIdents && isAtRule(node) && isDashedIdentAtRuleName(node.name)) {
       const { token, diagnostics } = parseDashedIdentAtRule(node);
       allDiagnostics.push(...diagnostics);
       if (token) localTokens.push(token);
-    } else if (dashedIdents && isAtRuleNode(node) && isMediaAtRule(node.name)) {
+    } else if (dashedIdents && isAtRule(node) && isMediaAtRuleName(node.name)) {
       tokenReferences.push(...parseDashedIdentMediaQuery(node));
-    } else if (dashedIdents && isAtRuleNode(node) && isContainerAtRule(node.name)) {
+    } else if (dashedIdents && isAtRule(node) && isContainerAtRuleName(node.name)) {
       tokenReferences.push(...parseDashedIdentContainerQuery(node));
-    } else if (isAtImportNode(node)) {
-      const parsed = parseAtImport(node);
+    } else if (isAtRule(node) && isImportAtRuleName(node.name)) {
+      const parsed = parseImportAtRule(node);
       if (parsed !== undefined) {
         tokenImporters.push({ type: 'all', ...parsed });
       }
-    } else if (isAtValueNode(node)) {
-      const { atValue, diagnostics } = parseAtValue(node);
+    } else if (isAtRule(node) && isValueAtRuleName(node.name)) {
+      const { atValue, diagnostics } = parseValueAtRule(node);
       allDiagnostics.push(...diagnostics);
       if (atValue === undefined) return;
       if (atValue.type === 'declaration') {
@@ -90,29 +86,29 @@ function collectTokens(ast: Root, keyframes: boolean, dashedIdents: boolean) {
         const { type: _, ...rest } = atValue;
         tokenImporters.push({ ...rest, type: 'named' });
       }
-    } else if (keyframes && isAtKeyframesNode(node)) {
-      const { keyframe, diagnostics } = parseAtKeyframes(node);
+    } else if (keyframes && isAtRule(node) && isKeyframesAtRuleName(node.name)) {
+      const { keyframe, diagnostics } = parseKeyframesAtRule(node);
       allDiagnostics.push(...diagnostics);
       if (keyframe) {
         localTokens.push({ name: keyframe.name, loc: keyframe.loc, declarationLoc: keyframe.declarationLoc });
       }
-    } else if (isRuleNode(node)) {
+    } else if (isRule(node)) {
       const { classSelectors, diagnostics } = parseRule(node);
       allDiagnostics.push(...diagnostics);
       for (const classSelector of classSelectors) {
         localTokens.push(classSelector);
       }
-    } else if (keyframes && isDeclarationNode(node) && isAnimationNameProp(node.prop)) {
+    } else if (keyframes && isDeclaration(node) && isAnimationNameProp(node.prop)) {
       const { references, diagnostics } = parseAnimationNameProp(node);
       allDiagnostics.push(...diagnostics);
       tokenReferences.push(...references);
-    } else if (keyframes && isDeclarationNode(node) && isAnimationProp(node.prop)) {
+    } else if (keyframes && isDeclaration(node) && isAnimationProp(node.prop)) {
       const { references, diagnostics } = parseAnimationProp(node);
       allDiagnostics.push(...diagnostics);
       tokenReferences.push(...references);
-    } else if (isDeclarationNode(node) && isComposesProp(node.prop)) {
+    } else if (isDeclaration(node) && isComposesProp(node.prop)) {
       tokenReferences.push(...parseComposesProp(node));
-    } else if (dashedIdents && isDeclarationNode(node)) {
+    } else if (dashedIdents && isDeclaration(node)) {
       const { localTokens: tokens, references } = parseDashedIdentDecl(node);
       localTokens.push(...tokens);
       tokenReferences.push(...references);

--- a/packages/core/src/parser/dashed-ident-parser.test.ts
+++ b/packages/core/src/parser/dashed-ident-parser.test.ts
@@ -2,14 +2,14 @@ import dedent from 'dedent';
 import { describe, expect, test } from 'vite-plus/test';
 import { fakeAtRule, fakeDeclaration } from '../test/ast.js';
 import {
-  isDashedIdentAtRule,
+  isDashedIdentAtRuleName,
   parseDashedIdentAtRule,
   parseDashedIdentContainerQuery,
   parseDashedIdentDecl,
   parseDashedIdentMediaQuery,
 } from './dashed-ident-parser.js';
 
-describe('isDashedIdentAtRule', () => {
+describe('isDashedIdentAtRuleName', () => {
   test.each([
     ['property', true],
     ['custom-media', true],
@@ -18,7 +18,7 @@ describe('isDashedIdentAtRule', () => {
     ['keyframes', false],
     ['import', false],
   ])('%s -> %s', (name, expected) => {
-    expect(isDashedIdentAtRule(name)).toBe(expected);
+    expect(isDashedIdentAtRuleName(name)).toBe(expected);
   });
 });
 

--- a/packages/core/src/parser/dashed-ident-parser.ts
+++ b/packages/core/src/parser/dashed-ident-parser.ts
@@ -33,7 +33,7 @@ function isCustomPropertyDecl(prop: string): boolean {
   return prop.startsWith('--');
 }
 
-export function isDashedIdentAtRule(name: string): boolean {
+export function isDashedIdentAtRuleName(name: string): boolean {
   return DASHED_IDENT_AT_RULE_NAMES.has(name.toLowerCase());
 }
 
@@ -90,11 +90,11 @@ export function parseDashedIdentAtRule(atRule: AtRule): ParseAtRuleResult {
   };
 }
 
-export function isMediaAtRule(name: string): boolean {
+export function isMediaAtRuleName(name: string): boolean {
   return name.toLowerCase() === 'media';
 }
 
-export function isContainerAtRule(name: string): boolean {
+export function isContainerAtRuleName(name: string): boolean {
   return name.toLowerCase() === 'container';
 }
 

--- a/packages/core/src/parser/key-frame-parser.test.ts
+++ b/packages/core/src/parser/key-frame-parser.test.ts
@@ -1,9 +1,9 @@
 import dedent from 'dedent';
 import { describe, expect, test } from 'vite-plus/test';
 import { fakeAtKeyframes, fakeRoot } from '../test/ast.js';
-import { parseAtKeyframes } from './key-frame-parser.js';
+import { parseKeyframesAtRule } from './key-frame-parser.js';
 
-describe('parseAtKeyframes', () => {
+describe('parseKeyframesAtRule', () => {
   test('valid', () => {
     const atKeyframes = fakeAtKeyframes(
       fakeRoot(dedent`
@@ -18,7 +18,7 @@ describe('parseAtKeyframes', () => {
         @keyframes :global(global) {}
       `),
     );
-    const result = atKeyframes.map(parseAtKeyframes);
+    const result = atKeyframes.map(parseKeyframesAtRule);
     expect(result).toMatchInlineSnapshot(`
       [
         {
@@ -127,7 +127,7 @@ describe('parseAtKeyframes', () => {
         @keyframes :local(local) {}
       `),
     );
-    const result = atKeyframes.map(parseAtKeyframes);
+    const result = atKeyframes.map(parseKeyframesAtRule);
     expect(result).toMatchInlineSnapshot(`
       [
         {

--- a/packages/core/src/parser/key-frame-parser.ts
+++ b/packages/core/src/parser/key-frame-parser.ts
@@ -26,12 +26,8 @@ interface ParseAtKeyframesResult {
  * @returns Parsed keyframe information and diagnostics
  */
 export function parseKeyframesAtRule(atKeyframes: AtRule): ParseAtKeyframesResult {
-  // Extract keyframe name from params
-  // e.g., "@keyframes fadeIn { ... }" -> keyframeName = "fadeIn"
-  // e.g., "@keyframes :local(slideOut) { ... }" -> keyframeName = ":local(slideOut)"
   const keyframeName = atKeyframes.params;
 
-  // Ignore empty keyframe names
   if (keyframeName === '') {
     return { diagnostics: [] };
   }
@@ -41,7 +37,6 @@ export function parseKeyframesAtRule(atKeyframes: AtRule): ParseAtKeyframesResul
     end: atKeyframes.positionBy({ index: `@keyframes${atKeyframes.raws.afterName!}${keyframeName}`.length }),
   };
 
-  // Handle :local() and :global() wrappers
   if (keyframeName.startsWith(':local(') && keyframeName.endsWith(')')) {
     // For simplicity of implementation, css-modules-kit does not support `:local(...)`.
     return {
@@ -55,7 +50,6 @@ export function parseKeyframesAtRule(atKeyframes: AtRule): ParseAtKeyframesResul
       ],
     };
   } else if (keyframeName.startsWith(':global(') && keyframeName.endsWith(')')) {
-    // Ignore keyframes wrapped in :global()
     return { diagnostics: [] };
   }
 

--- a/packages/core/src/parser/key-frame-parser.ts
+++ b/packages/core/src/parser/key-frame-parser.ts
@@ -25,7 +25,7 @@ interface ParseAtKeyframesResult {
  * @param atKeyframes The @keyframes at-rule to parse
  * @returns Parsed keyframe information and diagnostics
  */
-export function parseAtKeyframes(atKeyframes: AtRule): ParseAtKeyframesResult {
+export function parseKeyframesAtRule(atKeyframes: AtRule): ParseAtKeyframesResult {
   // Extract keyframe name from params
   // e.g., "@keyframes fadeIn { ... }" -> keyframeName = "fadeIn"
   // e.g., "@keyframes :local(slideOut) { ... }" -> keyframeName = ":local(slideOut)"


### PR DESCRIPTION
## What

Internal refactor of the CSS Module parser. No behavior or public API changes.

- Unify predicate/parse function naming so each name reflects its argument type:
  - type guards (take a node) match postcss type names: `isAtRule` / `isRule` / `isDeclaration`
  - name predicates (take a string) use a `~AtRuleName` suffix: `isImportAtRuleName`, `isValueAtRuleName`, etc.
  - parse functions use `parse~AtRule`: `parseImportAtRule`, `parseValueAtRule`, `parseKeyframesAtRule`
- In `collectTokens`, branch on the node type once per node instead of re-running the same type guard in every branch.
- Drop self-evident comments in `key-frame-parser.ts`.

## Verification

- `vp check` passes (format, lint, type check)
- `vp test --project unit packages/core` passes (228 tests)

## Note

Found a separate case-sensitivity bug while working on this (#424). It is a behavior change, so it is intentionally left out of this PR.