### PR TITLE
fix(core): match `from` / `global` / `as` keywords case-insensitively in `composes` and `@value`

### DIFF
--- a/.changeset/case-insensitive-keywords.md
+++ b/.changeset/case-insensitive-keywords.md
@@ -1,0 +1,5 @@
+---
+'@css-modules-kit/core': patch
+---
+
+fix(core): match `from` / `global` / `as` keywords case-insensitively in `composes` and `@value`

--- a/packages/core/src/parser/at-value-parser.test.ts
+++ b/packages/core/src/parser/at-value-parser.test.ts
@@ -411,6 +411,64 @@ describe('parseValueAtRule', () => {
       ]
     `);
   });
+  test('matches the `from` and `as` keywords case-insensitively', () => {
+    const atValues = fakeAtValues(fakeRoot(`@value import1 AS alias1 FROM "test.css";`));
+    const result = atValues.map(parseValueAtRule);
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "atValue": {
+            "entries": [
+              {
+                "loc": {
+                  "end": {
+                    "column": 15,
+                    "line": 1,
+                    "offset": 14,
+                  },
+                  "start": {
+                    "column": 8,
+                    "line": 1,
+                    "offset": 7,
+                  },
+                },
+                "localLoc": {
+                  "end": {
+                    "column": 25,
+                    "line": 1,
+                    "offset": 24,
+                  },
+                  "start": {
+                    "column": 19,
+                    "line": 1,
+                    "offset": 18,
+                  },
+                },
+                "localName": "alias1",
+                "name": "import1",
+              },
+            ],
+            "from": "test.css",
+            "fromLoc": {
+              "end": {
+                "column": 40,
+                "line": 1,
+                "offset": 39,
+              },
+              "start": {
+                "column": 32,
+                "line": 1,
+                "offset": 31,
+              },
+            },
+            "type": "importer",
+          },
+          "diagnostics": [],
+        },
+      ]
+    `);
+  });
+
   test('parses syntax unsupported by css-loader', () => {
     // NOTE: These syntaxes are not supported by css-loader, so css-modules-kit does not
     // guarantee any specific behavior for them. The snapshots below document how the current

--- a/packages/core/src/parser/at-value-parser.ts
+++ b/packages/core/src/parser/at-value-parser.ts
@@ -58,7 +58,7 @@ function isValueImporter(nodes: postcssValueParser.Node[]): boolean {
 }
 
 function findFromKeywordIndex(nodes: postcssValueParser.Node[]): number {
-  return nodes.findLastIndex((node) => node.type === 'word' && node.value === 'from');
+  return nodes.findLastIndex((node) => node.type === 'word' && node.value.toLowerCase() === 'from');
 }
 
 function parseValueImporter(atValue: AtRule, nodes: postcssValueParser.Node[]): ParseAtValueResult {
@@ -85,7 +85,7 @@ function parseValueImporter(atValue: AtRule, nodes: postcssValueParser.Node[]): 
       name: nameNode.value,
       loc: calcAtValueParamsLoc(atValue, nameNode.sourceIndex, nameNode.value.length),
     };
-    const localNode = words[1]?.value === 'as' ? words[2] : undefined;
+    const localNode = words[1]?.value.toLowerCase() === 'as' ? words[2] : undefined;
     if (localNode !== undefined) {
       entry.localName = localNode.value;
       entry.localLoc = calcAtValueParamsLoc(atValue, localNode.sourceIndex, localNode.value.length);

--- a/packages/core/src/parser/composes-parser.test.ts
+++ b/packages/core/src/parser/composes-parser.test.ts
@@ -229,6 +229,52 @@ describe('parseComposesProp', () => {
     `);
   });
 
+  test('matches the `from` keyword case-insensitively', () => {
+    const decl = fakeDeclaration(`.a_1 { composes: a_2 FROM './a.module.css' }`);
+    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`
+      [
+        {
+          "entries": [
+            {
+              "loc": {
+                "end": {
+                  "column": 21,
+                  "line": 1,
+                  "offset": 20,
+                },
+                "start": {
+                  "column": 18,
+                  "line": 1,
+                  "offset": 17,
+                },
+              },
+              "name": "a_2",
+            },
+          ],
+          "from": "./a.module.css",
+          "fromLoc": {
+            "end": {
+              "column": 42,
+              "line": 1,
+              "offset": 41,
+            },
+            "start": {
+              "column": 28,
+              "line": 1,
+              "offset": 27,
+            },
+          },
+          "type": "external",
+        },
+      ]
+    `);
+  });
+
+  test('matches the `global` keyword case-insensitively', () => {
+    const decl = fakeDeclaration('.a_1 { composes: a_2 from GLOBAL }');
+    expect(parseComposesProp(decl)).toMatchInlineSnapshot(`[]`);
+  });
+
   test('extracts local and external references according to the `from` clause of each item', () => {
     const decl = fakeDeclaration(`.a_1 { composes: a_2, a_3 from './a.module.css', a_4 from global, a_5 }`);
     expect(parseComposesProp(decl)).toMatchInlineSnapshot(`

--- a/packages/core/src/parser/composes-parser.ts
+++ b/packages/core/src/parser/composes-parser.ts
@@ -43,7 +43,7 @@ function hasFromClause(item: postcssValueParser.Node[]): boolean {
 }
 
 function findFromKeywordIndex(item: postcssValueParser.Node[]): number {
-  return item.findLastIndex((node) => node.type === 'word' && node.value === 'from');
+  return item.findLastIndex((node) => node.type === 'word' && node.value.toLowerCase() === 'from');
 }
 
 /**
@@ -53,7 +53,7 @@ function findFromKeywordIndex(item: postcssValueParser.Node[]): number {
 function isValidFromClauseTail(tail: postcssValueParser.Node[]): boolean {
   if (tail.length !== 1) return false;
   const node = tail[0]!;
-  return node.type === 'string' || (node.type === 'word' && node.value === 'global');
+  return node.type === 'string' || (node.type === 'word' && node.value.toLowerCase() === 'global');
 }
 
 /** Create a local token reference for each class name in `nodes`. */


### PR DESCRIPTION
Fixes #422

## Summary

CSS keywords are ASCII case-insensitive, but the `from` / `global` keywords in `composes` and the `from` / `as` keywords in `@value` were compared case-sensitively. As a result, uppercase spellings like `composes: foo FROM './x.css'` or `@value a AS b FROM './x.css'` were not recognized as keywords. This PR makes these comparisons case-insensitive, matching how `var()` references already treat keywords.

## Test Plan

```console
$ vp check
$ vp test --project unit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)