### PR TITLE
fix(core): match `@import` / `@value` / `@keyframes` at-rule names case-insensitively

### DIFF
--- a/.changeset/case-insensitive-at-rule-names.md
+++ b/.changeset/case-insensitive-at-rule-names.md
@@ -1,0 +1,5 @@
+---
+'@css-modules-kit/core': patch
+---
+
+fix(core): match `@import` / `@value` / `@keyframes` at-rule names case-insensitively

--- a/packages/core/src/parser/css-module-parser.test.ts
+++ b/packages/core/src/parser/css-module-parser.test.ts
@@ -983,6 +983,18 @@ describe('parseCSSModule', () => {
       ]
     `);
   });
+  test('matches at-rule names case-insensitively', () => {
+    const cssModule = parseCSSModule(
+      dedent`
+        @IMPORT './a.module.css';
+        @VALUE b: red;
+        @KEYFRAMES fade {}
+      `,
+      options,
+    );
+    expect(cssModule.tokenImporters.map((importer) => importer.from)).toStrictEqual(['./a.module.css']);
+    expect(cssModule.localTokens.map((token) => token.name)).toStrictEqual(['b', 'fade']);
+  });
   test('does not collect dashed-ident tokens if dashedIdents is false', () => {
     const cssModule = parseCSSModule('.a_1 { --foo: red; color: var(--foo); }', { ...options, dashedIdents: false });
     expect(cssModule.localTokens.map((token) => token.name)).toStrictEqual(['a_1']);

--- a/packages/core/src/parser/css-module-parser.ts
+++ b/packages/core/src/parser/css-module-parser.ts
@@ -35,15 +35,15 @@ function isAtRule(node: Node): node is AtRule {
 }
 
 function isImportAtRuleName(name: string): boolean {
-  return name === 'import';
+  return name.toLowerCase() === 'import';
 }
 
 function isValueAtRuleName(name: string): boolean {
-  return name === 'value';
+  return name.toLowerCase() === 'value';
 }
 
 function isKeyframesAtRuleName(name: string): boolean {
-  return name === 'keyframes';
+  return name.toLowerCase() === 'keyframes';
 }
 
 function isRule(node: Node): node is Rule {


### PR DESCRIPTION
Fixes #424

## Summary

Per the CSS Syntax spec, at-keywords are ASCII case-insensitive. However, `@import`, `@value`, and `@keyframes` were matched case-sensitively, so uppercase variants like `@IMPORT` were silently ignored. Other at-rules (`@media`, `@container`, `@property`, etc.) were already matched case-insensitively. This PR makes the remaining three consistent with them.

## Verification

```bash
vp check
vp test --project unit
```

All checks and 298 unit tests pass, including a new test that parses `@IMPORT` / `@VALUE` / `@KEYFRAMES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)