### PR TITLE
fix(core): honor the `from` clause of `var()` inside `@container style()` query values

### DIFF
--- a/.changeset/style-query-var-from-clause.md
+++ b/.changeset/style-query-var-from-clause.md
@@ -1,0 +1,5 @@
+---
+'@css-modules-kit/core': patch
+---
+
+fix(core): honor the `from` clause of `var()` inside `@container style()` query values

--- a/examples/1-basic/src/a.module.css
+++ b/examples/1-basic/src/a.module.css
@@ -22,6 +22,7 @@
   color: var(--custom-property), var(--custom-property from './c.module.css');
 }
 @container style(--custom-property) {}
+@container style(color: var(--custom-property)) {}
 
 /* @property */
 @property --property {}

--- a/packages/core/src/parser/dashed-ident-parser.test.ts
+++ b/packages/core/src/parser/dashed-ident-parser.test.ts
@@ -575,6 +575,63 @@ describe('parseDashedIdentContainerQuery', () => {
     `);
   });
 
+  test('extracts an external reference from a var() with a file specifier in a style query value', () => {
+    expect(parseDashedIdentContainerQuery(fakeAtRule(`@container style(--a: var(--b from "./c.module.css")) {}`)))
+      .toMatchInlineSnapshot(`
+        [
+          {
+            "loc": {
+              "end": {
+                "column": 21,
+                "line": 1,
+                "offset": 20,
+              },
+              "start": {
+                "column": 18,
+                "line": 1,
+                "offset": 17,
+              },
+            },
+            "name": "--a",
+            "type": "local",
+          },
+          {
+            "entries": [
+              {
+                "loc": {
+                  "end": {
+                    "column": 30,
+                    "line": 1,
+                    "offset": 29,
+                  },
+                  "start": {
+                    "column": 27,
+                    "line": 1,
+                    "offset": 26,
+                  },
+                },
+                "name": "--b",
+              },
+            ],
+            "from": "./c.module.css",
+            "fromLoc": {
+              "end": {
+                "column": 51,
+                "line": 1,
+                "offset": 50,
+              },
+              "start": {
+                "column": 37,
+                "line": 1,
+                "offset": 36,
+              },
+            },
+            "type": "external",
+          },
+        ]
+      `);
+  });
+
   test('extracts a reference from a var() in a style query value', () => {
     expect(parseDashedIdentContainerQuery(fakeAtRule('@container style(--accent: var(--theme)) {}')))
       .toMatchInlineSnapshot(`

--- a/packages/core/src/parser/dashed-ident-parser.test.ts
+++ b/packages/core/src/parser/dashed-ident-parser.test.ts
@@ -552,6 +552,33 @@ describe('parseDashedIdentContainerQuery', () => {
     `);
   });
 
+  // A style query tests the computed value of a property rather than declaring it. So even for
+  // a name-defining property like `anchor-name`, the queried `--foo` refers to a name declared
+  // elsewhere and must be a reference, not a token definition.
+  test('extracts a reference from a name-defining property in a style query', () => {
+    expect(parseDashedIdentContainerQuery(fakeAtRule('@container style(anchor-name: --foo) {}')))
+      .toMatchInlineSnapshot(`
+        [
+          {
+            "loc": {
+              "end": {
+                "column": 36,
+                "line": 1,
+                "offset": 35,
+              },
+              "start": {
+                "column": 31,
+                "line": 1,
+                "offset": 30,
+              },
+            },
+            "name": "--foo",
+            "type": "local",
+          },
+        ]
+      `);
+  });
+
   test('extracts a reference from a style feature nested in a style query', () => {
     expect(parseDashedIdentContainerQuery(fakeAtRule('@container style((--accent)) {}'))).toMatchInlineSnapshot(`
       [

--- a/packages/core/src/parser/dashed-ident-parser.ts
+++ b/packages/core/src/parser/dashed-ident-parser.ts
@@ -103,8 +103,8 @@ export function isContainerAtRuleName(name: string): boolean {
  * `@media (--foo) { ... }`, which references a `@custom-media --foo`. References nested
  * in a condition (e.g. `@media ((--foo))` or `@media (not (--foo))`) are also extracted.
  */
-export function parseDashedIdentMediaQuery(atRule: AtRule): LocalTokenReference[] {
-  const references: LocalTokenReference[] = [];
+export function parseDashedIdentMediaQuery(atRule: AtRule): TokenReference[] {
+  const references: TokenReference[] = [];
   // A custom media reference is always parenthesized (it sits where a media feature does),
   // which postcss-value-parser represents as a function node with an empty name.
   for (const node of postcssValueParser(atRule.params).nodes) {
@@ -121,8 +121,8 @@ export function parseDashedIdentMediaQuery(atRule: AtRule): LocalTokenReference[
  * Boolean style queries (e.g. `style((--a: red) or (--b: blue))`) and `style()` nested
  * in a condition are also extracted.
  */
-export function parseDashedIdentContainerQuery(atRule: AtRule): LocalTokenReference[] {
-  const references: LocalTokenReference[] = [];
+export function parseDashedIdentContainerQuery(atRule: AtRule): TokenReference[] {
+  const references: TokenReference[] = [];
   const walk = (nodes: postcssValueParser.Node[]): void => {
     for (const node of nodes) {
       if (node.type !== 'function') continue;
@@ -140,31 +140,35 @@ export function parseDashedIdentContainerQuery(atRule: AtRule): LocalTokenRefere
 /**
  * Collect `<dashed-ident>` references from the `<media-condition>` in `@media (<media-condition>)`
  * and the `<style-query>` in `@container style(<style-query>)`. Recurse into nested groups
- * (e.g. `(--a) or (--b)`, `not (--a)`) as well as functions within values (e.g. `var(--b)` in `--a: var(--b)`).
+ * (e.g. `(--a) or (--b)`, `not (--a)`). Functions within values (e.g. `var(--b)` in `--a: var(--b)`)
+ * are parsed like declaration values, so the `from` clause of `var()` is honored.
  */
-function collectFromConditionOrQuery(atRule: AtRule, nodes: postcssValueParser.Node[]): LocalTokenReference[] {
-  const references: LocalTokenReference[] = [];
+function collectFromConditionOrQuery(atRule: AtRule, nodes: postcssValueParser.Node[]): TokenReference[] {
+  const references: TokenReference[] = [];
+  const calcLoc = createAtRuleParamsLocCalculator(atRule);
   const walk = (nodes: postcssValueParser.Node[]): void => {
     const nameNode = nodes.find((n) => n.type === 'word' && n.value.startsWith('--'));
-    if (nameNode) references.push(createAtRuleParamReference(atRule, nameNode));
+    if (nameNode) references.push(createLocalReference(calcLoc, nameNode));
     for (const node of nodes) {
-      if (node.type === 'function') walk(node.nodes);
+      if (node.type !== 'function') continue;
+      // A parenthesized group is represented as a function node with an empty name.
+      if (node.value === '') {
+        walk(node.nodes);
+      } else {
+        references.push(...collectFromValueNodes([node], 'none', calcLoc).references);
+      }
     }
   };
   walk(nodes);
   return references;
 }
 
-function createAtRuleParamReference(atRule: AtRule, node: postcssValueParser.Node): LocalTokenReference {
+function createAtRuleParamsLocCalculator(atRule: AtRule): CalcValueLoc {
   const base = `@${atRule.name}${atRule.raws.afterName ?? ''}`.length;
-  return {
-    type: 'local',
-    name: node.value,
-    loc: {
-      start: atRule.positionBy({ index: base + node.sourceIndex }),
-      end: atRule.positionBy({ index: base + node.sourceIndex + node.value.length }),
-    },
-  };
+  return (sourceIndex, length) => ({
+    start: atRule.positionBy({ index: base + sourceIndex }),
+    end: atRule.positionBy({ index: base + sourceIndex + length }),
+  });
 }
 
 function calcPropLoc(decl: Declaration): Location {
@@ -174,7 +178,19 @@ function calcPropLoc(decl: Declaration): Location {
   };
 }
 
+/** Calculate the location of a range in the parsed value, given its source index and length. */
+type CalcValueLoc = (sourceIndex: number, length: number) => Location;
+
 function collectFromDeclValue(decl: Declaration): ParseDeclResult {
+  const calcLoc: CalcValueLoc = (sourceIndex, length) => calcDeclValueLoc(decl, sourceIndex, length);
+  return collectFromValueNodes(postcssValueParser(decl.value).nodes, getBareDashedIdentRole(decl.prop), calcLoc);
+}
+
+function collectFromValueNodes(
+  nodes: postcssValueParser.Node[],
+  role: BareDashedIdentRole,
+  calcLoc: CalcValueLoc,
+): ParseDeclResult {
   const result: ParseDeclResult = { localTokens: [], references: [] };
   const walk = (nodes: postcssValueParser.Node[], role: BareDashedIdentRole): void => {
     for (const node of nodes) {
@@ -192,9 +208,9 @@ function collectFromDeclValue(decl: Declaration): ParseDeclResult {
         }
       } else if (node.type === 'word' && node.value.startsWith('--')) {
         if (role === 'definition') {
-          result.localTokens.push({ name: node.value, loc: calcNodeLoc(decl, node) });
+          result.localTokens.push({ name: node.value, loc: calcNodeLoc(calcLoc, node) });
         } else if (role === 'reference') {
-          result.references.push(createLocalReference(decl, node));
+          result.references.push(createLocalReference(calcLoc, node));
         }
       }
     }
@@ -204,7 +220,7 @@ function collectFromDeclValue(decl: Declaration): ParseDeclResult {
     // `var( <first-arg> , <fallback>? )`: the first argument holds the referenced custom
     // property name (and an optional `from` clause); the fallback is an arbitrary value.
     const [firstArg, fallback] = splitAtFirstComma(fn.nodes);
-    const reference = parseVarFirstArg(decl, firstArg);
+    const reference = parseVarFirstArg(calcLoc, firstArg);
     if (reference) result.references.push(reference);
     walk(fallback, 'none');
   };
@@ -215,56 +231,56 @@ function collectFromDeclValue(decl: Declaration): ParseDeclResult {
     const [firstArg, fallback] = splitAtFirstComma(fn.nodes);
     const nameNode = firstArg.find((n) => n.type !== 'space');
     if (nameNode?.type === 'word' && nameNode.value.startsWith('--')) {
-      result.references.push(createLocalReference(decl, nameNode));
+      result.references.push(createLocalReference(calcLoc, nameNode));
     }
     walk(fallback, 'none');
   };
 
-  walk(postcssValueParser(decl.value).nodes, getBareDashedIdentRole(decl.prop));
+  walk(nodes, role);
   return result;
 }
 
 /** Parse `--foo` or `--foo from <specifier>` from the first argument of a `var()` call. */
-function parseVarFirstArg(decl: Declaration, firstArg: postcssValueParser.Node[]): TokenReference | undefined {
+function parseVarFirstArg(calcLoc: CalcValueLoc, firstArg: postcssValueParser.Node[]): TokenReference | undefined {
   const meaningful = firstArg.filter((n) => n.type !== 'space');
   const nameNode = meaningful[0];
   if (nameNode?.type !== 'word' || !nameNode.value.startsWith('--')) return undefined;
 
   const fromIndex = meaningful.findIndex((n) => n.type === 'word' && n.value.toLowerCase() === 'from');
-  if (fromIndex === -1) return createLocalReference(decl, nameNode);
+  if (fromIndex === -1) return createLocalReference(calcLoc, nameNode);
 
   const tail = meaningful.slice(fromIndex + 1);
   const specifier = tail.length === 1 ? tail[0] : undefined;
   if (specifier?.type === 'string') {
-    return createExternalReference(decl, nameNode, specifier);
+    return createExternalReference(calcLoc, nameNode, specifier);
   }
   // `from global` does not produce a token reference.
   if (specifier?.type === 'word' && specifier.value.toLowerCase() === 'global') {
     return undefined;
   }
-  return createLocalReference(decl, nameNode);
+  return createLocalReference(calcLoc, nameNode);
 }
 
-function createLocalReference(decl: Declaration, node: postcssValueParser.Node): LocalTokenReference {
-  return { type: 'local', name: node.value, loc: calcNodeLoc(decl, node) };
+function createLocalReference(calcLoc: CalcValueLoc, node: postcssValueParser.Node): LocalTokenReference {
+  return { type: 'local', name: node.value, loc: calcNodeLoc(calcLoc, node) };
 }
 
 function createExternalReference(
-  decl: Declaration,
+  calcLoc: CalcValueLoc,
   nameNode: postcssValueParser.Node,
   specifierNode: postcssValueParser.StringNode,
 ): ExternalTokenReference {
   return {
     type: 'external',
-    entries: [{ name: nameNode.value, loc: calcNodeLoc(decl, nameNode) }],
+    entries: [{ name: nameNode.value, loc: calcNodeLoc(calcLoc, nameNode) }],
     from: specifierNode.value,
     // The location of the specifier without quotes.
-    fromLoc: calcDeclValueLoc(decl, specifierNode.sourceIndex + 1, specifierNode.value.length),
+    fromLoc: calcLoc(specifierNode.sourceIndex + 1, specifierNode.value.length),
   };
 }
 
-function calcNodeLoc(decl: Declaration, node: postcssValueParser.Node): Location {
-  return calcDeclValueLoc(decl, node.sourceIndex, node.value.length);
+function calcNodeLoc(calcLoc: CalcValueLoc, node: postcssValueParser.Node): Location {
+  return calcLoc(node.sourceIndex, node.value.length);
 }
 
 /** Split function arguments at the first top-level comma into the first argument and the remaining fallback nodes. */

--- a/packages/core/src/parser/dashed-ident-parser.ts
+++ b/packages/core/src/parser/dashed-ident-parser.ts
@@ -8,7 +8,6 @@ import type {
   Token,
   TokenReference,
 } from '../type.js';
-import { calcDeclValueLoc } from './decl-value-location.js';
 
 /** Properties that declare a `<dashed-ident>` in their value. */
 const DECLARING_PROP_RE = /^(?:anchor-name|view-timeline-name|scroll-timeline-name|view-timeline|scroll-timeline)$/iu;
@@ -145,30 +144,21 @@ export function parseDashedIdentContainerQuery(atRule: AtRule): TokenReference[]
  */
 function collectFromConditionOrQuery(atRule: AtRule, nodes: postcssValueParser.Node[]): TokenReference[] {
   const references: TokenReference[] = [];
-  const calcLoc = createAtRuleParamsLocCalculator(atRule);
   const walk = (nodes: postcssValueParser.Node[]): void => {
     const nameNode = nodes.find((n) => n.type === 'word' && n.value.startsWith('--'));
-    if (nameNode) references.push(createLocalReference(calcLoc, nameNode));
+    if (nameNode) references.push(createLocalReference(atRule, nameNode));
     for (const node of nodes) {
       if (node.type !== 'function') continue;
       // A parenthesized group is represented as a function node with an empty name.
       if (node.value === '') {
         walk(node.nodes);
       } else {
-        references.push(...collectFromValueNodes([node], 'none', calcLoc).references);
+        references.push(...collectFromValueNodes(atRule, [node], 'none').references);
       }
     }
   };
   walk(nodes);
   return references;
-}
-
-function createAtRuleParamsLocCalculator(atRule: AtRule): CalcValueLoc {
-  const base = `@${atRule.name}${atRule.raws.afterName ?? ''}`.length;
-  return (sourceIndex, length) => ({
-    start: atRule.positionBy({ index: base + sourceIndex }),
-    end: atRule.positionBy({ index: base + sourceIndex + length }),
-  });
 }
 
 function calcPropLoc(decl: Declaration): Location {
@@ -178,18 +168,30 @@ function calcPropLoc(decl: Declaration): Location {
   };
 }
 
-/** Calculate the location of a range in the parsed value, given its source index and length. */
-type CalcValueLoc = (sourceIndex: number, length: number) => Location;
+/**
+ * Calculate the location of a range in the value parsed by postcss-value-parser,
+ * given its source index and length. The parsed value is the declaration value
+ * when `parent` is a declaration, or the params when `parent` is an at-rule.
+ */
+function calcValueLoc(parent: Declaration | AtRule, sourceIndex: number, length: number): Location {
+  const base =
+    parent.type === 'decl'
+      ? parent.prop.length + parent.raws.between!.length
+      : `@${parent.name}${parent.raws.afterName ?? ''}`.length;
+  return {
+    start: parent.positionBy({ index: base + sourceIndex }),
+    end: parent.positionBy({ index: base + sourceIndex + length }),
+  };
+}
 
 function collectFromDeclValue(decl: Declaration): ParseDeclResult {
-  const calcLoc: CalcValueLoc = (sourceIndex, length) => calcDeclValueLoc(decl, sourceIndex, length);
-  return collectFromValueNodes(postcssValueParser(decl.value).nodes, getBareDashedIdentRole(decl.prop), calcLoc);
+  return collectFromValueNodes(decl, postcssValueParser(decl.value).nodes, getBareDashedIdentRole(decl.prop));
 }
 
 function collectFromValueNodes(
+  parent: Declaration | AtRule,
   nodes: postcssValueParser.Node[],
   role: BareDashedIdentRole,
-  calcLoc: CalcValueLoc,
 ): ParseDeclResult {
   const result: ParseDeclResult = { localTokens: [], references: [] };
   const walk = (nodes: postcssValueParser.Node[], role: BareDashedIdentRole): void => {
@@ -208,9 +210,9 @@ function collectFromValueNodes(
         }
       } else if (node.type === 'word' && node.value.startsWith('--')) {
         if (role === 'definition') {
-          result.localTokens.push({ name: node.value, loc: calcNodeLoc(calcLoc, node) });
+          result.localTokens.push({ name: node.value, loc: calcNodeLoc(parent, node) });
         } else if (role === 'reference') {
-          result.references.push(createLocalReference(calcLoc, node));
+          result.references.push(createLocalReference(parent, node));
         }
       }
     }
@@ -220,7 +222,7 @@ function collectFromValueNodes(
     // `var( <first-arg> , <fallback>? )`: the first argument holds the referenced custom
     // property name (and an optional `from` clause); the fallback is an arbitrary value.
     const [firstArg, fallback] = splitAtFirstComma(fn.nodes);
-    const reference = parseVarFirstArg(calcLoc, firstArg);
+    const reference = parseVarFirstArg(parent, firstArg);
     if (reference) result.references.push(reference);
     walk(fallback, 'none');
   };
@@ -231,7 +233,7 @@ function collectFromValueNodes(
     const [firstArg, fallback] = splitAtFirstComma(fn.nodes);
     const nameNode = firstArg.find((n) => n.type !== 'space');
     if (nameNode?.type === 'word' && nameNode.value.startsWith('--')) {
-      result.references.push(createLocalReference(calcLoc, nameNode));
+      result.references.push(createLocalReference(parent, nameNode));
     }
     walk(fallback, 'none');
   };
@@ -241,46 +243,49 @@ function collectFromValueNodes(
 }
 
 /** Parse `--foo` or `--foo from <specifier>` from the first argument of a `var()` call. */
-function parseVarFirstArg(calcLoc: CalcValueLoc, firstArg: postcssValueParser.Node[]): TokenReference | undefined {
+function parseVarFirstArg(
+  parent: Declaration | AtRule,
+  firstArg: postcssValueParser.Node[],
+): TokenReference | undefined {
   const meaningful = firstArg.filter((n) => n.type !== 'space');
   const nameNode = meaningful[0];
   if (nameNode?.type !== 'word' || !nameNode.value.startsWith('--')) return undefined;
 
   const fromIndex = meaningful.findIndex((n) => n.type === 'word' && n.value.toLowerCase() === 'from');
-  if (fromIndex === -1) return createLocalReference(calcLoc, nameNode);
+  if (fromIndex === -1) return createLocalReference(parent, nameNode);
 
   const tail = meaningful.slice(fromIndex + 1);
   const specifier = tail.length === 1 ? tail[0] : undefined;
   if (specifier?.type === 'string') {
-    return createExternalReference(calcLoc, nameNode, specifier);
+    return createExternalReference(parent, nameNode, specifier);
   }
   // `from global` does not produce a token reference.
   if (specifier?.type === 'word' && specifier.value.toLowerCase() === 'global') {
     return undefined;
   }
-  return createLocalReference(calcLoc, nameNode);
+  return createLocalReference(parent, nameNode);
 }
 
-function createLocalReference(calcLoc: CalcValueLoc, node: postcssValueParser.Node): LocalTokenReference {
-  return { type: 'local', name: node.value, loc: calcNodeLoc(calcLoc, node) };
+function createLocalReference(parent: Declaration | AtRule, node: postcssValueParser.Node): LocalTokenReference {
+  return { type: 'local', name: node.value, loc: calcNodeLoc(parent, node) };
 }
 
 function createExternalReference(
-  calcLoc: CalcValueLoc,
+  parent: Declaration | AtRule,
   nameNode: postcssValueParser.Node,
   specifierNode: postcssValueParser.StringNode,
 ): ExternalTokenReference {
   return {
     type: 'external',
-    entries: [{ name: nameNode.value, loc: calcNodeLoc(calcLoc, nameNode) }],
+    entries: [{ name: nameNode.value, loc: calcNodeLoc(parent, nameNode) }],
     from: specifierNode.value,
     // The location of the specifier without quotes.
-    fromLoc: calcLoc(specifierNode.sourceIndex + 1, specifierNode.value.length),
+    fromLoc: calcValueLoc(parent, specifierNode.sourceIndex + 1, specifierNode.value.length),
   };
 }
 
-function calcNodeLoc(calcLoc: CalcValueLoc, node: postcssValueParser.Node): Location {
-  return calcLoc(node.sourceIndex, node.value.length);
+function calcNodeLoc(parent: Declaration | AtRule, node: postcssValueParser.Node): Location {
+  return calcValueLoc(parent, node.sourceIndex, node.value.length);
 }
 
 /** Split function arguments at the first top-level comma into the first argument and the remaining fallback nodes. */


### PR DESCRIPTION
Fixes #423

## Changes

Previously, a `var()` with a `from` clause inside a `@container style()` query value was collected as a local token reference, ignoring the `from` clause:

```css
@container style(--a: var(--b from './other.module.css')) {
}
```

Now `--b` is treated as an external token reference to `./other.module.css`, the same as in a declaration value. `var(--b from global)` is likewise excluded from references, also matching declaration values.

## Test plan

- `vp test --project unit`
- `vp check --fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)