### PR TITLE
feat(core, ts-plugin, codegen, vscode): deprecate `cmkOptions.keyframes` in favor of `cmkOptions.animation`

### DIFF
--- a/.changeset/deprecate-keyframes-option.md
+++ b/.changeset/deprecate-keyframes-option.md
@@ -1,0 +1,8 @@
+---
+'@css-modules-kit/core': minor
+'@css-modules-kit/ts-plugin': minor
+'@css-modules-kit/codegen': minor
+'css-modules-kit-vscode': minor
+---
+
+feat(core, ts-plugin, codegen, vscode): deprecate `cmkOptions.keyframes` in favor of `cmkOptions.animation`

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ When this option is `true`, `import { button } from '...'` will be added. When t
 }
 ```
 
-### `cmkOptions.keyframes`
+### `cmkOptions.animation`
 
 Type: `boolean`, Default: `true`
 
@@ -222,10 +222,14 @@ Determines whether to generate the [token](docs/glossary.md#token) of keyframes 
     // ...
   },
   "cmkOptions": {
-    "keyframes": false,
+    "animation": false,
   },
 }
 ```
+
+### `cmkOptions.keyframes`
+
+Deprecated: Use [`cmkOptions.animation`](#cmkoptionsanimation) instead.
 
 ### `cmkOptions.dashedIdents`
 

--- a/packages/codegen/src/project.test.ts
+++ b/packages/codegen/src/project.test.ts
@@ -480,6 +480,32 @@ describe('getDiagnostics', () => {
       ]
     `);
   });
+  test('reports semantic diagnostics when project diagnostics contain only warnings', async () => {
+    const iff = await createIFF({
+      'tsconfig.json': '{ "cmkOptions": { "enabled": true, "keyframes": true } }',
+      'src/a.module.css': `@import './non-existent.module.css';`,
+    });
+    const project = createProject({ project: iff.rootDir });
+    const diagnostics = project.getDiagnostics();
+    expect(formatDiagnostics(diagnostics, iff.rootDir)).toMatchInlineSnapshot(`
+      [
+        {
+          "category": "warning",
+          "text": "\`keyframes\` in <rootDir>/tsconfig.json is deprecated. Use the \`animation\` option instead.",
+        },
+        {
+          "category": "error",
+          "fileName": "<rootDir>/src/a.module.css",
+          "length": 25,
+          "start": {
+            "column": 10,
+            "line": 1,
+          },
+          "text": "Cannot import module './non-existent.module.css'",
+        },
+      ]
+    `);
+  });
   test('skips semantic diagnostics when project or syntactic diagnostics exist', async () => {
     const iff = await createIFF({
       'tsconfig.json': '{ "cmkOptions": { "enabled": true, "dtsOutDir": 1 } }',

--- a/packages/codegen/src/project.ts
+++ b/packages/codegen/src/project.ts
@@ -155,15 +155,15 @@ export function createProject(args: ProjectArgs): Project {
     return parseCSSModule(text, {
       fileName,
       includeSyntaxError: true,
-      keyframes: config.keyframes,
+      animation: config.animation,
       dashedIdents: config.dashedIdents,
     });
   }
 
   function getDiagnostics(): Diagnostic[] {
     const diagnostics: Diagnostic[] = [...getProjectDiagnostics(), ...getSyntacticDiagnostics()];
-    // If there are project or syntactic diagnostics, skip semantic diagnostics
-    if (diagnostics.length > 0) return diagnostics;
+    // If there are project or syntactic errors, skip semantic diagnostics
+    if (diagnostics.some((diagnostic) => diagnostic.category === 'error')) return diagnostics;
     diagnostics.push(...getSemanticDiagnostics());
     return diagnostics;
   }

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -26,7 +26,7 @@ describe('readConfigFile', () => {
         arbitraryExtensions: false,
         namedExports: false,
         prioritizeNamedImports: false,
-        keyframes: true,
+        animation: true,
         dashedIdents: false,
         enabled: false,
         compilerOptions: expect.any(Object),
@@ -48,7 +48,7 @@ describe('readConfigFile', () => {
             "arbitraryExtensions": true,
             "namedExports": true,
             "prioritizeNamedImports": true,
-            "keyframes": false,
+            "animation": false,
             "dashedIdents": true,
             "enabled": true
           }
@@ -63,7 +63,7 @@ describe('readConfigFile', () => {
         arbitraryExtensions: true,
         namedExports: true,
         prioritizeNamedImports: true,
-        keyframes: false,
+        animation: false,
         dashedIdents: true,
         enabled: true,
         compilerOptions: expect.objectContaining({
@@ -88,7 +88,7 @@ describe('readConfigFile', () => {
               "arbitraryExtensions": true,
               "namedExports": true,
               "prioritizeNamedImports": true,
-              "keyframes": false,
+              "animation": false,
               "dashedIdents": true,
               "enabled": true
             }
@@ -104,7 +104,7 @@ describe('readConfigFile', () => {
           arbitraryExtensions: true,
           namedExports: true,
           prioritizeNamedImports: true,
-          keyframes: false,
+          animation: false,
           dashedIdents: true,
           enabled: true,
           compilerOptions: expect.objectContaining({
@@ -377,6 +377,98 @@ describe('readConfigFile', () => {
             {
               category: 'error',
               text: `\`arbitraryExtensions\` in ${iff.paths['tsconfig.json']} must be a boolean.`,
+            },
+          ],
+        }),
+      );
+    });
+    test('reports an error if `animation` is not a boolean', async () => {
+      const iff = await createIFF({
+        'tsconfig.json': '{ "cmkOptions": { "animation": 1 } }',
+      });
+      expect(readConfigFile(iff.rootDir).diagnostics).toStrictEqual([
+        {
+          category: 'error',
+          text: `\`animation\` in ${iff.paths['tsconfig.json']} must be a boolean.`,
+        },
+      ]);
+    });
+  });
+  describe('deprecated `keyframes` option', () => {
+    test('adopts the `keyframes` value as `animation` and reports a deprecation warning', async () => {
+      const iff = await createIFF({
+        'tsconfig.json': '{ "cmkOptions": { "keyframes": false } }',
+      });
+      expect(readConfigFile(iff.rootDir)).toStrictEqual(
+        expect.objectContaining({
+          animation: false,
+          diagnostics: [
+            {
+              category: 'warning',
+              text: `\`keyframes\` in ${iff.paths['tsconfig.json']} is deprecated. Use the \`animation\` option instead.`,
+            },
+          ],
+        }),
+      );
+    });
+    test('inherits the `keyframes` value from the extended tsconfig and reports a deprecation warning', async () => {
+      const iff = await createIFF({
+        'tsconfig.base.json': '{ "cmkOptions": { "keyframes": false } }',
+        'tsconfig.json': '{ "extends": "./tsconfig.base.json" }',
+      });
+      expect(readConfigFile(iff.rootDir)).toStrictEqual(
+        expect.objectContaining({
+          animation: false,
+          diagnostics: [
+            {
+              category: 'warning',
+              text: `\`keyframes\` in ${iff.paths['tsconfig.base.json']} is deprecated. Use the \`animation\` option instead.`,
+            },
+          ],
+        }),
+      );
+    });
+    test('reports an error and adopts the `animation` value if both `keyframes` and `animation` are specified', async () => {
+      const iff = await createIFF({
+        'tsconfig.json': '{ "cmkOptions": { "keyframes": true, "animation": false } }',
+      });
+      expect(readConfigFile(iff.rootDir)).toStrictEqual(
+        expect.objectContaining({
+          animation: false,
+          diagnostics: [
+            {
+              category: 'warning',
+              text: `\`keyframes\` in ${iff.paths['tsconfig.json']} is deprecated. Use the \`animation\` option instead.`,
+            },
+            {
+              category: 'error',
+              text: `\`keyframes\` and \`animation\` in ${iff.paths['tsconfig.json']} cannot be used together. Remove \`keyframes\`.`,
+            },
+          ],
+        }),
+      );
+    });
+    test('reports an error if `keyframes` and `animation` are specified in separate tsconfig files linked by `extends`', async () => {
+      const iff = await createIFF({
+        'tsconfig.base.json': '{ "cmkOptions": { "keyframes": true } }',
+        'tsconfig.json': dedent`
+          {
+            "extends": "./tsconfig.base.json",
+            "cmkOptions": { "animation": false }
+          }
+        `,
+      });
+      expect(readConfigFile(iff.rootDir)).toStrictEqual(
+        expect.objectContaining({
+          animation: false,
+          diagnostics: [
+            {
+              category: 'warning',
+              text: `\`keyframes\` in ${iff.paths['tsconfig.base.json']} is deprecated. Use the \`animation\` option instead.`,
+            },
+            {
+              category: 'error',
+              text: `\`keyframes\` and \`animation\` in ${iff.paths['tsconfig.json']} cannot be used together. Remove \`keyframes\`.`,
             },
           ],
         }),

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -18,7 +18,7 @@ export interface CMKConfig {
   arbitraryExtensions: boolean;
   namedExports: boolean;
   prioritizeNamedImports: boolean;
-  keyframes: boolean;
+  animation: boolean;
   dashedIdents: boolean;
   /**
    * A root directory to resolve relative path entries in the config file to.
@@ -78,6 +78,7 @@ interface UnnormalizedRawConfig {
   arbitraryExtensions?: boolean;
   namedExports?: boolean;
   prioritizeNamedImports?: boolean;
+  animation?: boolean;
   keyframes?: boolean;
   dashedIdents?: boolean;
 }
@@ -161,7 +162,21 @@ function parseRawData(raw: unknown, tsConfigSourceFile: ts.TsConfigSourceFile, b
         });
       }
     }
+    if ('animation' in raw.cmkOptions) {
+      if (typeof raw.cmkOptions.animation === 'boolean') {
+        result.config.animation = raw.cmkOptions.animation;
+      } else {
+        result.diagnostics.push({
+          category: 'error',
+          text: `\`animation\` in ${tsConfigSourceFile.fileName} must be a boolean.`,
+        });
+      }
+    }
     if ('keyframes' in raw.cmkOptions) {
+      result.diagnostics.push({
+        category: 'warning',
+        text: `\`keyframes\` in ${tsConfigSourceFile.fileName} is deprecated. Use the \`animation\` option instead.`,
+      });
       if (typeof raw.cmkOptions.keyframes === 'boolean') {
         result.config.keyframes = raw.cmkOptions.keyframes;
       } else {
@@ -281,6 +296,13 @@ export function readConfigFile(project: string): CMKConfig {
     }
   }
 
+  if (parsedTsConfig.config.animation !== undefined && parsedTsConfig.config.keyframes !== undefined) {
+    parsedTsConfig.diagnostics.push({
+      category: 'error',
+      text: `\`keyframes\` and \`animation\` in ${configFileName} cannot be used together. Remove \`keyframes\`.`,
+    });
+  }
+
   return {
     // If `include` is not specified, fallback to the default include spec。
     // ref: https://github.com/microsoft/TypeScript/blob/caf1aee269d1660b4d2a8b555c2d602c97cb28d7/src/compiler/commandLineParser.ts#L3102
@@ -292,7 +314,7 @@ export function readConfigFile(project: string): CMKConfig {
     arbitraryExtensions: parsedTsConfig.config.arbitraryExtensions ?? false,
     namedExports: parsedTsConfig.config.namedExports ?? false,
     prioritizeNamedImports: parsedTsConfig.config.prioritizeNamedImports ?? false,
-    keyframes: parsedTsConfig.config.keyframes ?? true,
+    animation: parsedTsConfig.config.animation ?? parsedTsConfig.config.keyframes ?? true,
     dashedIdents: parsedTsConfig.config.dashedIdents ?? false,
     enabled: parsedTsConfig.config.enabled ?? false,
     basePath,

--- a/packages/core/src/parser/css-module-parser.test.ts
+++ b/packages/core/src/parser/css-module-parser.test.ts
@@ -5,7 +5,7 @@ import { parseCSSModule, type ParseCSSModuleOptions } from './css-module-parser.
 const options: ParseCSSModuleOptions = {
   fileName: '/test.module.css',
   includeSyntaxError: true,
-  keyframes: true,
+  animation: true,
   dashedIdents: false,
 };
 
@@ -963,8 +963,8 @@ describe('parseCSSModule', () => {
     	}
     `);
   });
-  test('does not include the token of keyframes if keyframes is false', () => {
-    const cssModule = parseCSSModule('@keyframes slide-in {}', { ...options, keyframes: false });
+  test('does not include the token of keyframes if animation is false', () => {
+    const cssModule = parseCSSModule('@keyframes slide-in {}', { ...options, animation: false });
     expect(cssModule.localTokens).toMatchInlineSnapshot(`[]`);
   });
   test('collects local tokens from dashed-ident declarations', () => {

--- a/packages/core/src/parser/css-module-parser.test.ts
+++ b/packages/core/src/parser/css-module-parser.test.ts
@@ -819,9 +819,6 @@ describe('parseCSSModule', () => {
     	}
     `);
   });
-  // TODO: Support local tokens by CSS variables. This is supported by lightningcss.
-  // https://github.com/parcel-bundler/lightningcss/blob/a3390fd4140ca87f5035595d22bc9357cf72177e/src/css_modules.rs#L34
-
   // TODO: Support local tokens by grid names. This is supported by lightningcss.
   // https://github.com/parcel-bundler/lightningcss/blob/a3390fd4140ca87f5035595d22bc9357cf72177e/src/css_modules.rs#L40
 

--- a/packages/core/src/parser/css-module-parser.ts
+++ b/packages/core/src/parser/css-module-parser.ts
@@ -57,7 +57,7 @@ function isDeclaration(node: Node): node is Declaration {
 /**
  * Collect tokens from the AST.
  */
-function collectTokens(ast: Root, keyframes: boolean, dashedIdents: boolean) {
+function collectTokens(ast: Root, animation: boolean, dashedIdents: boolean) {
   const allDiagnostics: DiagnosticWithDetachedLocation[] = [];
   const localTokens: Token[] = [];
   const tokenImporters: TokenImporter[] = [];
@@ -87,7 +87,7 @@ function collectTokens(ast: Root, keyframes: boolean, dashedIdents: boolean) {
           const { type: _, ...rest } = atValue;
           tokenImporters.push({ ...rest, type: 'named' });
         }
-      } else if (keyframes && isKeyframesAtRuleName(node.name)) {
+      } else if (animation && isKeyframesAtRuleName(node.name)) {
         const { keyframe, diagnostics } = parseKeyframesAtRule(node);
         allDiagnostics.push(...diagnostics);
         if (keyframe) {
@@ -101,11 +101,11 @@ function collectTokens(ast: Root, keyframes: boolean, dashedIdents: boolean) {
         localTokens.push(classSelector);
       }
     } else if (isDeclaration(node)) {
-      if (keyframes && isAnimationNameProp(node.prop)) {
+      if (animation && isAnimationNameProp(node.prop)) {
         const { references, diagnostics } = parseAnimationNameProp(node);
         allDiagnostics.push(...diagnostics);
         tokenReferences.push(...references);
-      } else if (keyframes && isAnimationProp(node.prop)) {
+      } else if (animation && isAnimationProp(node.prop)) {
         const { references, diagnostics } = parseAnimationProp(node);
         allDiagnostics.push(...diagnostics);
         tokenReferences.push(...references);
@@ -125,7 +125,7 @@ export interface ParseCSSModuleOptions {
   fileName: string;
   /** Whether to include syntax errors from diagnostics */
   includeSyntaxError: boolean;
-  keyframes: boolean;
+  animation: boolean;
   dashedIdents: boolean;
 }
 /**
@@ -134,7 +134,7 @@ export interface ParseCSSModuleOptions {
  */
 export function parseCSSModule(
   text: string,
-  { fileName, includeSyntaxError, keyframes, dashedIdents }: ParseCSSModuleOptions,
+  { fileName, includeSyntaxError, animation, dashedIdents }: ParseCSSModuleOptions,
 ): CSSModule {
   let ast: Root;
   const diagnosticFile = { fileName, text };
@@ -161,7 +161,7 @@ export function parseCSSModule(
     ast = safeParser(text, { from: fileName });
   }
 
-  const { localTokens, tokenImporters, tokenReferences, diagnostics } = collectTokens(ast, keyframes, dashedIdents);
+  const { localTokens, tokenImporters, tokenReferences, diagnostics } = collectTokens(ast, animation, dashedIdents);
   allDiagnostics.push(...diagnostics.map((diagnostic) => ({ ...diagnostic, file: diagnosticFile })));
   return {
     fileName,

--- a/packages/core/src/test/css-module.ts
+++ b/packages/core/src/test/css-module.ts
@@ -16,7 +16,7 @@ export function fakeCSSModule(args?: Partial<CSSModule>): CSSModule {
 
 export function readAndParseCSSModule(
   path: string,
-  options?: { keyframes?: boolean; dashedIdents?: boolean },
+  options?: { animation?: boolean; dashedIdents?: boolean },
 ): CSSModule | undefined {
   let text: string;
   try {
@@ -27,7 +27,7 @@ export function readAndParseCSSModule(
   return parseCSSModule(text, {
     fileName: path,
     includeSyntaxError: false,
-    keyframes: options?.keyframes ?? true,
+    animation: options?.animation ?? true,
     dashedIdents: options?.dashedIdents ?? false,
   });
 }

--- a/packages/core/src/test/faker.ts
+++ b/packages/core/src/test/faker.ts
@@ -11,7 +11,7 @@ export function fakeConfig(args?: Partial<CMKConfig>): CMKConfig {
     arbitraryExtensions: false,
     namedExports: false,
     prioritizeNamedImports: false,
-    keyframes: true,
+    animation: true,
     dashedIdents: false,
     basePath: '/app',
     configFileName: '/app/tsconfig.json',

--- a/packages/ts-plugin/src/language-plugin.ts
+++ b/packages/ts-plugin/src/language-plugin.ts
@@ -49,7 +49,7 @@ export function createCSSLanguagePlugin(
         // Therefore, if ts-plugin also reports it, the same error is reported twice.
         // To avoid this, ts-plugin does not report invalid syntax errors.
         includeSyntaxError: false,
-        keyframes: config.keyframes,
+        animation: config.animation,
         dashedIdents: config.dashedIdents,
       });
       // oxlint-disable-next-line prefer-const

--- a/packages/vscode/schemas/tsconfig.schema.json
+++ b/packages/vscode/schemas/tsconfig.schema.json
@@ -30,10 +30,17 @@
           "default": false,
           "markdownDescription": "Whether to prioritize named imports over namespace imports when adding import statements. This option only takes effect when `cmkOptions.namedExports` is `true`.\n\nWhen this option is `true`, `import { button } from '...'` will be added. When this option is `false`, `import button from '...'` will be added."
         },
+        "animation": {
+          "type": "boolean",
+          "default": true,
+          "title": "animation",
+          "markdownDescription": "Determines whether to generate the [token](https://github.com/mizdra/css-modules-kit/blob/main/docs/glossary.md#token) of keyframes in the d.ts file."
+        },
         "keyframes": {
           "type": "boolean",
           "default": true,
           "title": "keyframes",
+          "deprecationMessage": "Deprecated: Use the `animation` option instead.",
           "markdownDescription": "Determines whether to generate the [token](https://github.com/mizdra/css-modules-kit/blob/main/docs/glossary.md#token) of keyframes in the d.ts file."
         },
         "dashedIdents": {


### PR DESCRIPTION
## Summary

- Added a new `cmkOptions.animation` option (`boolean`, default `true`). It behaves identically to `cmkOptions.keyframes`: it determines whether to generate the token of keyframes in the d.ts file.
- Deprecated `cmkOptions.keyframes`:
  - Specifying it reports a deprecation warning. It still works as before.
  - Specifying both `keyframes` and `animation` (even across `extends`) reports an error. In that case, the `animation` value takes effect.

Lightning CSS provides the equivalent feature under the name [`animation`](https://lightningcss.dev/css-modules.html). Aligning the option name with it reduces confusion, just like `dashedIdents` already does.

## How to verify

1. In a project using css-modules-kit, set `"cmkOptions": { "keyframes": false }` in `tsconfig.json` and run `npx cmk` — a deprecation warning is printed, and keyframes tokens are excluded from the generated d.ts as before.
2. Replace it with `"animation": false` — the warning disappears and the output stays the same.
3. Specify both `"keyframes"` and `"animation"` — an error is printed and `cmk` exits with a non-zero status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
