### PR TITLE
fix(ci): run windows-11-arm tests on Node.js 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,9 @@ jobs:
       fail-fast: false
       matrix:
         node: [26]
-        os: [ubuntu-24.04-arm, macos-latest]
+        os: [ubuntu-24.04-arm, macos-latest, windows-11-arm]
         stylelint-version: ['17']
         include:
-          # Windows is pinned to Node.js 24.15.0 because Node.js 24.16+ and 26.x bundle libuv 1.52.x,
-          # which has a Windows file-watching bug.
-          # ref: https://github.com/libuv/libuv/issues/5010
-          - node: '24.15.0'
-            os: windows-11-arm
-            stylelint-version: '17'
           # Configuration for Node.js 24
           - node: 24
             os: ubuntu-24.04-arm


### PR DESCRIPTION
## Summary

- Remove the workaround that pinned `windows-11-arm` in the `test` job to Node.js 24.15.0
- `windows-11-arm` now runs on Node.js 26, same as the other OSes in the matrix

The workaround was needed because Node.js 24.16+ and 26.x bundled a libuv version with a Windows file-watching bug ([libuv/libuv#5010](https://github.com/libuv/libuv/issues/5010)). This has since been fixed upstream, so the pin is no longer necessary.

## Test plan

- [ ] Confirm the `test (windows-11-arm)` job passes in CI on this PR