### PR TITLE
chore: use legacy `packageManager` field to work around changesets issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,11 +48,5 @@
     "vite": "catalog:",
     "vite-plus": "catalog:"
   },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^11.9.0",
-      "onFail": "download"
-    }
-  }
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }


### PR DESCRIPTION
## Summary

After #435 migrated to `devEngines.packageManager`, the Release workflow started failing ([log](https://github.com/mizdra/css-modules-kit/actions/runs/28958984111/job/85925318185)). `changeset publish` runs `npm publish` internally (changesets/changesets#965), and npm rejects the command because it does not match `devEngines.packageManager: pnpm`.

This PR reverts to the legacy `packageManager` field as a workaround. npm does not validate this field, so `changeset publish` works again. pnpm still auto-manages its own version via this field, so the pnpm@11 migration is kept.

Once changesets/changesets#2097 is released, we can migrate back to `devEngines`.

## How to verify

- Before this change, running any npm command (e.g. `npm view pnpm version`) inside the repo failed with `EBADDEVENGINES` — the same check that broke `changeset publish`. After this change, it succeeds.
- `pnpm install --frozen-lockfile` succeeds and pnpm 11.9.0 is selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)